### PR TITLE
db - cascade delete ops to relations; remove dataset hard delete

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -32,15 +32,15 @@ model dataset {
   projects         project_dataset[]
   accesses         data_access_log[]
   stage_requests   stage_request_log[]
-  @@unique([name, type])
+  @@unique([name, type, is_deleted])
 }
 
 model dataset_hierarchy {
   source_id       Int
   derived_id      Int
   assigned_at     DateTime @default(now()) @db.Timestamp(6)
-  source_dataset  dataset  @relation(name: "source_datasets", fields: [source_id], references: [id])
-  derived_dataset dataset  @relation(name: "derived_datasets", fields: [derived_id], references: [id])
+  source_dataset  dataset  @relation(name: "source_datasets", fields: [source_id], references: [id], onDelete: Cascade)
+  derived_dataset dataset  @relation(name: "derived_datasets", fields: [derived_id], references: [id], onDelete: Cascade)
 
   @@id([source_id, derived_id])
 }
@@ -55,7 +55,7 @@ model dataset_file {
   metadata       Json?
   status         String?
   dataset_id     Int
-  dataset        dataset                  @relation(fields: [dataset_id], references: [id], onDelete: NoAction)
+  dataset        dataset                  @relation(fields: [dataset_id], references: [id], onDelete: Cascade)
   parents        dataset_file_hierarchy[] @relation("child")
   children       dataset_file_hierarchy[] @relation("parent")
   accesses       data_access_log[]
@@ -79,9 +79,9 @@ model dataset_audit {
   old_data   Json?
   new_data   Json?
   user_id    Int?
-  user       user?    @relation(fields: [user_id], references: [id])
-  dataset_id Int
-  dataset    dataset? @relation(fields: [dataset_id], references: [id])
+  user       user?    @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  dataset_id Int?
+  dataset    dataset? @relation(fields: [dataset_id], references: [id], onDelete: Cascade)
 }
 
 model dataset_state {
@@ -89,7 +89,7 @@ model dataset_state {
   timestamp  DateTime @default(now()) @db.Timestamp(6)
   metadata   Json?
   dataset_id Int
-  dataset    dataset? @relation(fields: [dataset_id], references: [id])
+  dataset    dataset? @relation(fields: [dataset_id], references: [id], onDelete: Cascade)
 
   @@id([timestamp, dataset_id, state])
 }
@@ -142,7 +142,7 @@ model user_password {
   created_at DateTime @default(now()) @db.Timestamp(6)
   updated_at DateTime @default(now()) @updatedAt @db.Timestamp(6)
   user_id    Int      @unique
-  user       user     @relation(fields: [user_id], references: [id])
+  user       user     @relation(fields: [user_id], references: [id], onDelete: Cascade)
 }
 
 model user_login {
@@ -150,14 +150,14 @@ model user_login {
   last_login DateTime @default(now()) @db.Timestamp(6)
   method     String
   user_id    Int      @unique
-  user       user     @relation(fields: [user_id], references: [id])
+  user       user     @relation(fields: [user_id], references: [id], onDelete: Cascade)
 }
 
 model user_settings {
   id       Int  @id @default(autoincrement())
   user_id  Int  @unique
   settings Json
-  users    user @relation(fields: [user_id], references: [id], onDelete: NoAction)
+  users    user @relation(fields: [user_id], references: [id], onDelete: Cascade)
 }
 
 model contact {
@@ -166,7 +166,7 @@ model contact {
   value       String
   description String?
   user_id     Int?
-  user        user?             @relation(fields: [user_id], references: [id], onDelete: NoAction)
+  user        user?             @relation(fields: [user_id], references: [id], onDelete: Cascade)
   projects    project_contact[]
 
   @@unique([type, value])
@@ -182,8 +182,8 @@ model role {
 model user_role {
   user_id     Int
   role_id     Int
-  roles       role     @relation(fields: [role_id], references: [id])
-  users       user     @relation(fields: [user_id], references: [id])
+  roles       role     @relation(fields: [role_id], references: [id], onDelete: Cascade)
+  users       user     @relation(fields: [user_id], references: [id], onDelete: Cascade)
   assigned_at DateTime @default(now())
 
   @@id([user_id, role_id])
@@ -192,7 +192,7 @@ model user_role {
 model workflow {
   id         String   @id
   dataset_id Int?
-  dataset    dataset? @relation(fields: [dataset_id], references: [id], onDelete: NoAction)
+  dataset    dataset? @relation(fields: [dataset_id], references: [id], onDelete: Cascade)
 }
 
 model metric {

--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -393,29 +393,19 @@ router.delete(
   isPermittedTo('delete'),
   validate([
     param('id').isInt().toInt(),
-    query('soft_delete').toBoolean().default(true),
   ]),
   asyncHandler(async (req, res, next) => {
     // #swagger.tags = ['datasets']
-    // #swagger.summary = For soft delete, starts a delete archive workflow and
-    // marks the dataset as deleted on success. Dataset is hard deleted only when there are no
-    // workflow association
+    // #swagger.summary = starts a delete archive workflow and
+    // marks the dataset as deleted on success.
     const _dataset = await datasetService.get_dataset({
       id: req.params.id,
       workflows: true,
     });
 
     if (_dataset) {
-      if (req.query.soft_delete) {
-        await datasetService.soft_delete(_dataset, req.user?.id);
-        res.send();
-      } else if ((_dataset.workflows?.length || 0) === 0) {
-        // no workflows - safe to delete
-        await datasetService.hard_delete(_dataset.id);
-        res.send();
-      } else {
-        next(createError.Conflict('Unable to delete as one or more workflows are associated with this bacth'));
-      }
+      await datasetService.soft_delete(_dataset, req.user?.id);
+      res.send();
     } else {
       next(createError(404));
     }

--- a/api/src/scripts/delete_datasets.js
+++ b/api/src/scripts/delete_datasets.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+const { PrismaClient } = require('@prisma/client');
+const _ = require('lodash/fp');
+
+const prisma = new PrismaClient();
+
+async function main() {
+  /**
+   * Deletes datasets by ids and all these following associations
+   * dataset_hierarchy, dataset_audit, dataset_state, dataset_file, dataset_file_hierarchy,
+   * project_dataset
+   *
+   * Usage: node src/scripts/delete_datasets.js <ids>
+   * ex: node src/scripts/delete_datasets.js 1 2 3
+   */
+  const args = process.argv.slice(2);
+  const ids = args.map(_.toInteger);
+
+  if (ids.every(_.isInteger)) {
+    const res = await prisma.dataset.deleteMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+    });
+    console.log(res);
+    return res;
+  }
+  console.error('one or more args is not a integer');
+}
+
+main()
+  .then(() => {
+    prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/api/src/services/dataset.js
+++ b/api/src/services/dataset.js
@@ -103,55 +103,6 @@ async function soft_delete(dataset, user_id) {
   });
 }
 
-async function hard_delete(id) {
-  const deleteFiles = prisma.dataset_file.deleteMany({
-    where: {
-      dataset_id: id,
-    },
-  });
-  const deleteWorkflows = prisma.workflow.deleteMany({
-    where: {
-      dataset_id: id,
-    },
-  });
-  const deleteAudit = prisma.dataset_audit.deleteMany({
-    where: {
-      dataset_id: id,
-    },
-  });
-  const deleteStates = prisma.dataset_state.deleteMany({
-    where: {
-      dataset_id: id,
-    },
-  });
-  const deleteAssociations = prisma.dataset_hierarchy.deleteMany({
-    where: {
-      OR: [
-        {
-          source_id: id,
-        },
-        {
-          derived_id: id,
-        },
-      ],
-    },
-  });
-  const deleteDataset = prisma.dataset.delete({
-    where: {
-      id,
-    },
-  });
-
-  await prisma.$transaction([
-    deleteFiles,
-    deleteWorkflows,
-    deleteAudit,
-    deleteStates,
-    deleteAssociations,
-    deleteDataset,
-  ]);
-}
-
 async function get_dataset({
   id = null,
   files = false,
@@ -511,7 +462,6 @@ async function add_files({ dataset_id, data }) {
 
 module.exports = {
   soft_delete,
-  hard_delete,
   INCLUDE_STATES,
   INCLUDE_WORKFLOWS,
   get_dataset,

--- a/workers/workers/api.py
+++ b/workers/workers/api.py
@@ -126,12 +126,13 @@ def dataset_setter(dataset: dict):
     return dataset
 
 
-def get_all_datasets(dataset_type=None, name=None, days_since_last_staged=None):
+def get_all_datasets(dataset_type=None, name=None, days_since_last_staged=None, deleted=False):
     with APIServerSession() as s:
         payload = {
             'type': dataset_type,
             'name': name,
-            'days_since_last_staged': days_since_last_staged
+            'days_since_last_staged': days_since_last_staged,
+            'deleted': deleted
         }
         r = s.get('datasets', params=payload)
         r.raise_for_status()

--- a/workers/workers/dataset.py
+++ b/workers/workers/dataset.py
@@ -33,11 +33,3 @@ def compute_staging_path(dataset: dict) -> tuple[Path, str]:
     staging_dir = Path(config['paths'][dataset_type]['stage']).resolve()
     alias = glom(dataset, 'metadata.stage_alias', default=stage_alias(dataset))
     return staging_dir / alias / dataset['name'], alias
-
-
-def create_if_does_not_exist(body):
-    _results = api.get_all_datasets(dataset_type=body['type'], name=body['name'])
-    dataset = next(iter(_results), None)
-    if not dataset:
-        dataset = api.create_dataset(body)
-    return dataset


### PR DESCRIPTION
**Description**

Refactored db schema - deletes of an entry of dataset, user, project, etc are cascaded to their associations. 

Removed the capability to delete dataset entries from UI / API. The datasets can only be marked as deleted by the operators. 

A script is added to remove the datasets by id intended to be of use for the admins.

```bash
$ node src/scripts/delete_datasets.js 1 2 3
{ count: 3 }
```

**Related Issue(s)**

Closes #30 



**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Checklist**

Before submitting this PR, please make sure that:

- [x] Your code passes linting and coding style checks.
- [x] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [x] Any relevant issue(s) have been linked to this PR.

**Additional Information**

Add any other information or context that may be relevant to this PR. This can include potential impacts, known issues, or future work related to this change.
