### PR TITLE
reduce metrics collection frequency

### DIFF
--- a/workers/ecosystem.config.js
+++ b/workers/ecosystem.config.js
@@ -35,7 +35,7 @@ module.exports = {
       log_date_format: "YYYY-MM-DD HH:mm Z",
       error_file: "../logs/workers/metrics.err",
       out_file: "../logs/workers/metrics.log",
-      cron_restart: "0 * * * *",
+      cron_restart: "00 21 * * *",
       autorestart: false,
       exp_backoff_restart_delay: 100,
       max_restarts: 3,


### PR DESCRIPTION
**Description**

Reduce metrics collection frequency

**Related Issue(s)**

Closes #95 

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [ ] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated
- [x] Other changes: [describe]

cron config changed.

Deployment: pm2 restart

**Checklist**

Before submitting this PR, please make sure that:

- [x] Your code passes linting and coding style checks.
- [x] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [x] Any relevant issue(s) have been linked to this PR.

**Additional Information**

Old metric data can be deleted with the following SQL

```sql
delete from metric where extract(hour from timestamp) != 21;
```

deletes all entries which are not made in 21st hour - only keeps one measurement per day taken during 21:00-21:59
