### PR TITLE
fix modal sizes

### DIFF
--- a/ui/src/components/dataset/Dataset.vue
+++ b/ui/src/components/dataset/Dataset.vue
@@ -144,6 +144,7 @@
           <va-modal
             :model-value="stage_modal"
             message="Stage all files in this dataset from the SDA?"
+            size="small"
             @ok="stage_dataset"
             @cancel="stage_modal = !stage_modal"
           />
@@ -151,7 +152,6 @@
           <!-- delete archive modal -->
           <va-modal
             :model-value="delete_archive_modal.visible"
-            max-width="480px"
             blur
             hide-default-actions
           >
@@ -300,10 +300,10 @@
 </template>
 
 <script setup>
-import DatasetService from "@/services/dataset";
-import workflowService from "@/services/workflow";
 import config from "@/config";
+import DatasetService from "@/services/dataset";
 import { formatBytes } from "@/services/utils";
+import workflowService from "@/services/workflow";
 import { useToastStore } from "@/stores/toast";
 const toast = useToastStore();
 const router = useRouter();

--- a/ui/src/components/dataset/EditDatasetModal.vue
+++ b/ui/src/components/dataset/EditDatasetModal.vue
@@ -6,6 +6,7 @@
     }`"
     no-outside-dismiss
     fixed-layout
+    size="small"
     ok-text="Edit"
     @ok="handleOk"
     @cancel="hide"

--- a/ui/src/components/filebrowser/FileBrowserSearchModal.vue
+++ b/ui/src/components/filebrowser/FileBrowserSearchModal.vue
@@ -3,11 +3,11 @@
     v-model="visible"
     fixed-layout
     hide-default-actions
-    size="large"
+    size="small"
     title="Advanced File Search"
   >
     <va-inner-loading :loading="loading">
-      <div class="w-96">
+      <div class="w-full">
         <va-form class="flex flex-col gap-3 md:gap-5">
           <!-- name filter -->
           <va-input

--- a/ui/src/components/project/DeleteProjectModal.vue
+++ b/ui/src/components/project/DeleteProjectModal.vue
@@ -6,6 +6,7 @@
     no-outside-dismiss
     fixed-layout
     ok-text="Delete"
+    size="small"
     @ok="handleOk"
     @cancel="hide"
   >

--- a/ui/src/components/project/datasets/ProjectDatasetsModal.vue
+++ b/ui/src/components/project/datasets/ProjectDatasetsModal.vue
@@ -17,8 +17,8 @@
 </template>
 
 <script setup>
-import { useProjectFormStore } from "@/stores/projects/projectForm";
 import projectService from "@/services/projects";
+import { useProjectFormStore } from "@/stores/projects/projectForm";
 
 const props = defineProps(["id"]);
 const emit = defineEmits(["update"]);

--- a/ui/src/components/project/datasets/StageDatasetModal.vue
+++ b/ui/src/components/project/datasets/StageDatasetModal.vue
@@ -3,6 +3,7 @@
     v-model="visible"
     title="Stage Dataset"
     okText="Stage"
+    size="small"
     @ok="handleOk"
     @close="hide"
     no-outside-dismiss
@@ -19,8 +20,8 @@
 </template>
 
 <script setup>
-import DatasetService from "@/services/dataset";
 import config from "@/config";
+import DatasetService from "@/services/dataset";
 
 const props = defineProps({
   dataset: {

--- a/ui/src/components/project/info/EditProjectInfoModal.vue
+++ b/ui/src/components/project/info/EditProjectInfoModal.vue
@@ -5,6 +5,7 @@
     no-outside-dismiss
     fixed-layout
     hide-default-actions
+    size="small"
   >
     <va-inner-loading :loading="loading" class="sm:w-96">
       <ProjectInfoForm />
@@ -27,8 +28,8 @@
 </template>
 
 <script setup>
-import { useProjectFormStore } from "@/stores/projects/projectForm";
 import projectService from "@/services/projects";
+import { useProjectFormStore } from "@/stores/projects/projectForm";
 
 const props = defineProps(["id"]);
 const emit = defineEmits(["update"]);

--- a/ui/src/components/project/users/ProjectUsersModal.vue
+++ b/ui/src/components/project/users/ProjectUsersModal.vue
@@ -4,6 +4,7 @@
     title="Manage Access"
     no-outside-dismiss
     fixed-layout
+    size="small"
     @ok="handleOk"
     @close="hide"
   >
@@ -17,8 +18,8 @@
 </template>
 
 <script setup>
-import { useProjectFormStore } from "@/stores/projects/projectForm";
 import projectService from "@/services/projects";
+import { useProjectFormStore } from "@/stores/projects/projectForm";
 
 const props = defineProps(["id"]);
 const emit = defineEmits(["update"]);


### PR DESCRIPTION
Vuestic's default modal width has changed with the new version. We now have to explicitly specify size="small" for some modals.

Closes #[118]