### PR TITLE
Disable API's pm2 file watcher in production docker deployment

### DIFF
--- a/api/ecosystem.config.js
+++ b/api/ecosystem.config.js
@@ -5,5 +5,5 @@ module.exports = [{
   instances: 2,
   exp_backoff_restart_delay: 100,
   max_restarts: 3,
-  watch: true,
+  watch: false,
 }];


### PR DESCRIPTION
Closes: https://github.com/IUSCA/bioloop/issues/181

Reasoning: File watching is not required in prod deployments. API can be restarted with `bin/deploy.sh`