### PR TITLE
102 - persist bundle metadata in separate table

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -357,6 +357,7 @@ Code to check if the requester to is authorized to `GET /users/dduck`. This rout
 
 ```javascript
 const { authenticate } = require('../middleware/auth');
+const ac = require('../services/accesscontrols');
 
 router.get('/:username',
   authenticate,

--- a/api/prisma/migrations/20240209020305_102_bundle/migration.sql
+++ b/api/prisma/migrations/20240209020305_102_bundle/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `bundle_size` on the `dataset` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "dataset" DROP COLUMN "bundle_size";
+
+-- CreateTable
+CREATE TABLE "bundle" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "size" BIGINT,
+    "md5" TEXT NOT NULL,
+    "dataset_id" INTEGER NOT NULL,
+
+    CONSTRAINT "bundle_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "bundle_dataset_id_key" ON "bundle"("dataset_id");
+
+-- AddForeignKey
+ALTER TABLE "bundle" ADD CONSTRAINT "bundle_dataset_id_fkey" FOREIGN KEY ("dataset_id") REFERENCES "dataset"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -15,7 +15,6 @@ model dataset {
   num_files        Int?
   du_size          BigInt?
   size             BigInt?
-  bundle_size      BigInt?
   description      String?
   created_at       DateTime            @default(now()) @db.Timestamp(6)
   updated_at       DateTime            @default(now()) @updatedAt @db.Timestamp(6)
@@ -34,6 +33,8 @@ model dataset {
   projects         project_dataset[]
   accesses         data_access_log[]
   stage_requests   stage_request_log[]
+  bundle           bundle?
+
   @@unique([name, type, is_deleted])
 }
 
@@ -48,19 +49,20 @@ model dataset_hierarchy {
 }
 
 model dataset_file {
-  id             Int                      @id @default(autoincrement())
-  name           String?
-  path           String
-  md5            String?
-  size           BigInt?
-  filetype       String?
-  metadata       Json?
-  status         String?
-  dataset_id     Int
-  dataset        dataset                  @relation(fields: [dataset_id], references: [id], onDelete: Cascade)
-  parents        dataset_file_hierarchy[] @relation("child")
-  children       dataset_file_hierarchy[] @relation("parent")
-  accesses       data_access_log[]
+  id         Int                      @id @default(autoincrement())
+  name       String?
+  path       String
+  md5        String?
+  size       BigInt?
+  filetype   String?
+  metadata   Json?
+  status     String?
+  dataset_id Int
+  dataset    dataset                  @relation(fields: [dataset_id], references: [id], onDelete: Cascade)
+  parents    dataset_file_hierarchy[] @relation("child")
+  children   dataset_file_hierarchy[] @relation("parent")
+  accesses   data_access_log[]
+
   @@unique([path, dataset_id])
   @@index([dataset_id])
 }
@@ -97,37 +99,48 @@ model dataset_state {
   @@id([timestamp, dataset_id, state])
 }
 
+model bundle {
+  id         Int      @id @default(autoincrement())
+  created_at DateTime @default(now()) @db.Timestamp(6)
+  name       String
+  path       String
+  size       BigInt?
+  md5        String
+  dataset_id Int      @unique
+  dataset    dataset  @relation(fields: [dataset_id], references: [id])
+}
+
 model data_access_log {
-  id            Int           @id @default(autoincrement())
-  timestamp     DateTime      @default(now()) @db.Timestamp(6)
-  access_type   access_type
-  file_id       Int?
-  dataset_file  dataset_file? @relation(fields: [file_id], references: [id])
-  dataset_id    Int?
-  dataset       dataset?      @relation(fields: [dataset_id], references: [id])
-  user_id       Int
-  user          user          @relation(fields: [user_id], references: [id])
+  id           Int           @id @default(autoincrement())
+  timestamp    DateTime      @default(now()) @db.Timestamp(6)
+  access_type  access_type
+  file_id      Int?
+  dataset_file dataset_file? @relation(fields: [file_id], references: [id])
+  dataset_id   Int?
+  dataset      dataset?      @relation(fields: [dataset_id], references: [id])
+  user_id      Int
+  user         user          @relation(fields: [user_id], references: [id])
 }
 
 model stage_request_log {
-  id            Int           @id @default(autoincrement())
-  timestamp     DateTime      @default(now()) @db.Timestamp(6)
-  dataset_id    Int?
-  dataset       dataset?      @relation(fields: [dataset_id], references: [id])
-  user_id       Int
-  user          user          @relation(fields: [user_id], references: [id])
+  id         Int      @id @default(autoincrement())
+  timestamp  DateTime @default(now()) @db.Timestamp(6)
+  dataset_id Int?
+  dataset    dataset? @relation(fields: [dataset_id], references: [id])
+  user_id    Int
+  user       user     @relation(fields: [user_id], references: [id])
 }
 
 model user {
-  id             Int             @id @default(autoincrement())
-  username       String          @unique @db.VarChar(100)
-  name           String?         @db.VarChar(100)
-  email          String          @unique @db.VarChar(100)
-  cas_id         String?         @unique @db.VarChar(100)
+  id             Int                 @id @default(autoincrement())
+  username       String              @unique @db.VarChar(100)
+  name           String?             @db.VarChar(100)
+  email          String              @unique @db.VarChar(100)
+  cas_id         String?             @unique @db.VarChar(100)
   notes          String?
-  created_at     DateTime        @default(now()) @db.Timestamp(6)
-  updated_at     DateTime        @default(now()) @updatedAt @db.Timestamp(6)
-  is_deleted     Boolean         @default(false)
+  created_at     DateTime            @default(now()) @db.Timestamp(6)
+  updated_at     DateTime            @default(now()) @updatedAt @db.Timestamp(6)
+  is_deleted     Boolean             @default(false)
   user_role      user_role[]
   settings       user_settings?
   contacts       contact[]

--- a/api/prisma/seed_data/staged_logs.js
+++ b/api/prisma/seed_data/staged_logs.js
@@ -12,13 +12,13 @@ function generate_staged_logs(num_years) {
 
   const staging_logs = [];
 
-  generate_date_range(start_date, end_date).forEach((date, i) => {
-    // choose a random value (b/w 0 and 10) for number of files staged on any given day
-    const num_staged_files = Math.floor(Math.random() * 10);
+  generate_date_range(start_date, end_date).forEach((date) => {
+    // choose a random value (b/w 0 and 2) for number of files staged on any given day
+    const num_staged_files = Math.floor(Math.random() * 2);
 
-    _.range(0, num_staged_files).forEach((j) => {
+    _.range(0, num_staged_files).forEach(() => {
       staging_logs.push({
-        state: `${i}-${j}`,
+        state: 'STAGED',
         timestamp: date,
         metadata: {},
         dataset_id: datasets[Math.floor(Math.random() * datasets.length)].id,

--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -198,6 +198,7 @@ router.get(
     query('limit').isInt().toInt().optional(),
     query('offset').isInt().toInt().optional(),
     query('sortBy').isObject().optional(),
+    query('bundle').optional().toBoolean(),
   ]),
   asyncHandler(async (req, res, next) => {
     // #swagger.tags = ['datasets']
@@ -224,6 +225,7 @@ router.get(
         ...datasetService.INCLUDE_WORKFLOWS,
         source_datasets: true,
         derived_datasets: true,
+        bundle: req.query.bundle || false,
       },
     };
 
@@ -269,6 +271,7 @@ router.get(
     query('last_task_run').toBoolean().default(false),
     query('prev_task_runs').toBoolean().default(false),
     query('only_active').toBoolean().default(false),
+    query('bundle').optional().toBoolean(),
   ]),
   dataset_access_check,
   asyncHandler(async (req, res, next) => {
@@ -282,6 +285,7 @@ router.get(
       last_task_run: req.query.last_task_run,
       prev_task_runs: req.query.prev_task_runs,
       only_active: req.query.only_active,
+      bundle: req.query.bundle || false,
     });
     res.json(dataset);
   }),
@@ -294,7 +298,7 @@ router.post(
   validate([
     body('du_size').optional().notEmpty().customSanitizer(BigInt), // convert to BigInt
     body('size').optional().notEmpty().customSanitizer(BigInt),
-    body('bundle_size').optional().notEmpty().customSanitizer(BigInt),
+    body('bundle').optional().isObject(),
   ]),
   asyncHandler(async (req, res, next) => {
     // #swagger.tags = ['datasets']
@@ -345,8 +349,7 @@ router.patch(
       .customSanitizer(BigInt), // convert to BigInt
     body('size').optional().notEmpty().bail()
       .customSanitizer(BigInt),
-    body('bundle_size').optional().notEmpty().bail()
-      .customSanitizer(BigInt),
+    body('bundle').optional().isObject(),
   ]),
   asyncHandler(async (req, res, next) => {
     // #swagger.tags = ['datasets']
@@ -365,6 +368,15 @@ router.patch(
 
     const { metadata, ...data } = req.body;
     data.metadata = _.merge(datasetToUpdate?.metadata)(metadata); // deep merge
+
+    if (req.body.bundle) {
+      data.bundle = {
+        upsert: {
+          create: req.body.bundle,
+          update: req.body.bundle,
+        },
+      };
+    }
 
     const dataset = await prisma.dataset.update({
       where: {
@@ -625,7 +637,7 @@ router.get(
     const isFileDownload = !!req.query.file_id;
 
     // Log the data access attempt first.
-    // Catch errors to ensure that logging does not get in the way of the rest of the method.
+    // Catch errors to ensure that logging does not get in the way of a token being returned.
     try {
       await prisma.data_access_log.create({
         data: {
@@ -653,12 +665,16 @@ router.get(
       where: {
         id: req.params.id,
       },
+      include: {
+        bundle: true,
+      },
     });
 
     if (dataset.metadata.stage_alias) {
       const download_file_path = isFileDownload
         ? `${dataset.metadata.stage_alias}/${file.path}`
-        : `${dataset.metadata.stage_alias}/${dataset.name}.tar`;
+        : `${dataset.metadata.bundle_alias}`;
+
       const download_token = await authService.get_download_token(download_file_path);
 
       const url = new URL(download_file_path, config.get('download_server.base_url'));

--- a/api/src/routes/projects.js
+++ b/api/src/routes/projects.js
@@ -195,6 +195,7 @@ router.get(
       orderBy: buildOrderByObject(Object.keys(sortBy)[0], Object.values(sortBy)[0]),
       include: {
         ...datasetService.INCLUDE_WORKFLOWS,
+        bundle: true,
       },
     };
 

--- a/api/src/services/dataset.js
+++ b/api/src/services/dataset.js
@@ -129,6 +129,7 @@ async function get_dataset({
   last_task_run = false,
   prev_task_runs = false,
   only_active = false,
+  bundle = false,
 }) {
   const fileSelect = files ? {
     select: {
@@ -148,6 +149,8 @@ async function get_dataset({
       files: fileSelect,
       ...INCLUDE_WORKFLOWS,
       ...INCLUDE_AUDIT_LOGS,
+      ...INCLUDE_STATES,
+      bundle,
       source_datasets: true,
       derived_datasets: true,
     },

--- a/docs/secure_download.md
+++ b/docs/secure_download.md
@@ -27,28 +27,37 @@ The UI and API are running on a node where the Slate Scratch path is not mounted
 
 ## 3. Staging the Dataset
 
-The Staging Dataset functionality allows users to request the download of dataset files through the UI or API. Staging a dataset involves the transfer of the requested dataset file from the SDA (Source Data Archive) to a temporary location known as the Slate Scratch path. This intermediate step ensures efficient and secure access to the dataset while preventing unauthorized access through path enumeration.
+The Staging Dataset functionality allows users to request the download of individual dataset files (or the entire dataset, as a bundled file) through the UI or API. Staging a dataset involves the transfer of the corresponding archived bundle from the SDA (Source Data Archive) to a temporary location known as the Slate Scratch path. This intermediate step ensures efficient and secure access to the dataset while preventing unauthorized access through path enumeration.
 
 Staging Process:
 
-- **User Request**: Users initiate a dataset file download request through either the user interface (UI) or the application programming interface (API).
+- **User Request**: Users initiate a dataset file/bundle download request through either the user interface (UI) or the application programming interface (API).
 
 - **Rhythm Workflow**: The request triggers a rhythm workflow "Stage" on the colo node where the celery tasks are registered. "stage_dataset", "validate_dataset", "setup_dataset_download" are the celery tasks involved in this workflow. 
 
-- **Path Randomization**: During dataset staging, a random string, in the form of a universally unique identifier (UUID) called `stage_alias`, is incorporated into the path. This UUID is generated to limit access to datasets through path enumeration. The staging path follows the pattern: `<stage_directory>/<dataset_stage_alias>/<dataset_name>`. "stage_dataset" celery task downloads the dataset tar from SDA and extarcts to this randomized path.
+- **Path Randomization**: During dataset staging, the path of the staged dataset files/bundle are obfuscated through the means of two random universally unique identifiers (UUIDs) called `stage_alias` and `bundle_alias`. This UUIDs are generated to limit access to datasets through path enumeration.
+  - The `stage_dataset` celery task downloads the dataset bundle from SDA, and extracts the dataset files and the bundle to their corresponding randomized paths.
+    - The dataset's staging path follows the pattern: `<stage_directory>/<dataset_stage_alias>/<dataset_name>`.
+    - The bundle's staging path follows the pattern: `<bundle_stage_directory>/<dataset_bundle_name>`.
 
 Example:
 ```
 /stage_directory/6a5b1734-98e8-4e47-ae5f-1a9e5d8d9f7c/dataset_name
+/bundle_stage_directory/bundle_name
 ```
 
-- **Symlink Creation**: A symlink `<download_path>/<dataset_stage_alias>` is created to point to `<stage_directory>/<dataset_stage_alias>/<dataset_name>`. This will be path given to the users who want to download the data from the Slate Scratch directly. The file download nginx server is configured to server files from the `<download_path>` directory.
+- **Symlink Creation**: Two symlinks are created to facilitate downloads. 
+  - `<download_path>/<dataset_stage_alias>`. This points to `<stage_directory>/<dataset_stage_alias>/<dataset_name>`. This will be path given to the users who want to download the dataset files from the Slate Scratch directly.
+  - `<download_path>/<dataset_bundle_alias>`. This points to `<bundle_stage_directory>/<dataset_bundle_alias>/<dataset_name>`. This will be path given to the users who want to download the dataset as a bundle from the Slate Scratch directly.
+
+The file download nginx server is configured to serve files from the `<download_path>` directory.
+
 
 To enhance security, the access control list (ACL) of the `<stage_directory>/<dataset_stage_alias>` directory is carefully configured. It is limited to granting only the "execute" permission bit (--x) for the "others" group. This permission setup ensures that users with access to the Slate Scratch path cannot browse or navigate through all datasets present in the directory. Instead, only users who possess the complete path `<stage_directory>/<dataset_stage_alias>/<dataset_name>` are allowed to read the contents of the staged dataset.
 
 #### UUID Generation
 
-The UUID used in the staging path is generated deterministically. It is a function of the dataset type, dataset name, and a salt string. This deterministic approach ensures consistency and allows authorized users to access the staged dataset when needed, while making it computationally infeasible for users to guess the path of other datasets.
+The UUIDs used in the staging/bundle paths are generated deterministically. They are a function of the dataset type, dataset (or bundle) name, and a salt string. This deterministic approach ensures consistency and allows authorized users to access the staged dataset/bundle when needed, while making it computationally infeasible for users to guess the path of other datasets.
 
 By implementing these measures, the Staging Dataset functionality maintains data security and privacy, preventing unauthorized access and ensuring the integrity of the staged datasets.
 

--- a/ui/src/components/dataset/Dataset.vue
+++ b/ui/src/components/dataset/Dataset.vue
@@ -22,14 +22,18 @@
               <DatasetInfo :dataset="dataset"></DatasetInfo>
               <div class="flex justify-end mt-3 pr-3 gap-3">
                 <!-- file browser -->
+
+                <!-- Download Modal -->
+                <DatasetDownloadModal ref="downloadModal" :dataset="dataset" />
                 <va-button
                   :disabled="!dataset.num_files"
-                  preset="primary"
-                  @click="navigateToFileBrowser"
-                  class="flex-none"
-                  :color="isDark ? '#9171f8' : '#A020F0'"
+                  class="flex-initial"
+                  color="primary"
+                  border-color="primary"
+                  preset="secondary"
+                  @click="openModalToDownloadDataset"
                 >
-                  <i-mdi-folder-open class="pr-2 text-xl" /> Browse Files
+                  <i-mdi-folder-open class="pr-2 text-2xl" /> Access Files
                 </va-button>
 
                 <!-- edit description -->
@@ -305,9 +309,8 @@ import DatasetService from "@/services/dataset";
 import toast from "@/services/toast";
 import { formatBytes } from "@/services/utils";
 import workflowService from "@/services/workflow";
-const router = useRouter();
-const route = useRoute();
-const isDark = useDark();
+
+const downloadModal = ref(null);
 
 const props = defineProps({ datasetId: String, appendFileBrowserUrl: Boolean });
 
@@ -340,7 +343,7 @@ const polling_interval = computed(() => {
 
 function fetch_dataset(show_loading = false) {
   loading.value = show_loading;
-  DatasetService.getById({ id: props.datasetId })
+  DatasetService.getById({ id: props.datasetId, bundle: true })
     .then((res) => {
       const _dataset = res.data;
       const _workflows = _dataset?.workflows || [];
@@ -445,12 +448,8 @@ function openModalToEditDataset() {
   editModal.value.show();
 }
 
-function navigateToFileBrowser() {
-  if (props.appendFileBrowserUrl) {
-    router.push(route.path + "/filebrowser");
-  } else {
-    router.push(`/datasets/${props.datasetId}/filebrowser`);
-  }
+function openModalToDownloadDataset() {
+  downloadModal.value.show();
 }
 </script>
 

--- a/ui/src/components/project/datasets/DatasetDownloadModal.vue
+++ b/ui/src/components/project/datasets/DatasetDownloadModal.vue
@@ -67,7 +67,8 @@
               <span class="text-lg">Download Archive</span>
               <span class="px-1"> - </span>
               <span class="">
-                Size: {{ formatBytes(dataset.bundle_size) }}
+                Transfer of file will use
+                {{ formatBytes(dataset.bundle.size) }} of bandwidth
               </span>
             </va-list-item-label>
           </va-list-item-section>

--- a/ui/src/components/project/datasets/ProjectDatasetsTable.vue
+++ b/ui/src/components/project/datasets/ProjectDatasetsTable.vue
@@ -135,11 +135,7 @@
   />
 
   <!-- Download Modal -->
-  <DatasetDownloadModal
-    ref="downloadModal"
-    :dataset="datasetToDownload"
-    :project-id="props.project.id"
-  />
+  <DatasetDownloadModal ref="downloadModal" :dataset="datasetToDownload" />
 
   <!-- Stage Modal -->
   <StageDatasetModal

--- a/ui/src/services/dataset.js
+++ b/ui/src/services/dataset.js
@@ -52,6 +52,7 @@ class DatasetService {
     last_task_run = false,
     prev_task_runs = false,
     only_active = false,
+    bundle = false,
   }) {
     return api.get(`/datasets/${id}`, {
       params: {
@@ -60,6 +61,7 @@ class DatasetService {
         last_task_run,
         prev_task_runs,
         only_active,
+        bundle,
       },
     });
   }

--- a/workers/ecosystem.config.js
+++ b/workers/ecosystem.config.js
@@ -68,6 +68,17 @@ module.exports = {
       autorestart: false,
       exp_backoff_restart_delay: 100,
       max_restarts: 3,
+    },
+    {
+      name: "populate_bundles",
+      script: "python",
+      args: "-u -m workers.scripts.populate_bundles",
+      watch: false,
+      interpreter: "",
+      log_date_format: "YYYY-MM-DD HH:mm Z",
+      error_file: "../logs/workers/populate_bundles.err",
+      out_file: "../logs/workers/populate_bundles.log",
+      autorestart: false,
     }
   ]
 }

--- a/workers/workers/api.py
+++ b/workers/workers/api.py
@@ -141,7 +141,7 @@ def get_all_datasets(
             'days_since_last_staged': days_since_last_staged,
             'deleted': deleted,
             'archived': archived,
-            'bundle': False
+            'bundle': bundle
         }
         r = s.get('datasets', params=payload)
         r.raise_for_status()

--- a/workers/workers/api.py
+++ b/workers/workers/api.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 from urllib.parse import urljoin
+import json
 
 import requests
 from glom import glom, assign as glom_assign
@@ -85,7 +86,7 @@ class APIServerSession(requests.Session):
 
 
 def str_to_int(d: dict, key: str):
-    d['du_size'] = utils.parse_number(d.get(key, None))
+    d[key] = utils.parse_number(d.get(key, None))
     return d
 
 
@@ -121,18 +122,26 @@ def dataset_getter(dataset: dict):
 def dataset_setter(dataset: dict):
     # convert du_size and size from int to string
     if dataset is not None:
-        for key in ['du_size', 'size', 'bundle_size']:
+        for key in ['du_size', 'size']:
             int_to_str(dataset, key)
     return dataset
 
 
-def get_all_datasets(dataset_type=None, name=None, days_since_last_staged=None, deleted=False):
+def get_all_datasets(
+        dataset_type=None,
+        name=None,
+        days_since_last_staged=None,
+        deleted=False,
+        archived=False,
+        bundle=False):
     with APIServerSession() as s:
         payload = {
             'type': dataset_type,
             'name': name,
             'days_since_last_staged': days_since_last_staged,
-            'deleted': deleted
+            'deleted': deleted,
+            'archived': archived,
+            'bundle': False
         }
         r = s.get('datasets', params=payload)
         r.raise_for_status()
@@ -140,12 +149,14 @@ def get_all_datasets(dataset_type=None, name=None, days_since_last_staged=None, 
         return [dataset_getter(dataset) for dataset in datasets]
 
 
-def get_dataset(dataset_id: str, files: bool = False):
+def get_dataset(dataset_id: str, files: bool = False, bundle: bool = False):
     with APIServerSession() as s:
         payload = {
-            'files': files
+            'files': files,
+            'bundle': bundle
         }
         r = s.get(f'datasets/{dataset_id}', params=payload)
+
         r.raise_for_status()
         return dataset_getter(r.json())
 

--- a/workers/workers/config/common.py
+++ b/workers/workers/config/common.py
@@ -40,11 +40,13 @@ config = {
         'RAW_DATA': {
             'archive': f'development/{YEAR}/raw_data',
             'stage': '/path/to/staged/raw_data',
+            'bundle': '/path/to/bundle/raw_data',
             'qc': '/path/to/qc'
         },
         'DATA_PRODUCT': {
             'archive': f'development/{YEAR}/data_products',
             'stage': '/path/to/staged/data_products',
+            'bundle': '/path/to/bundle/data_products',
         },
         'download_dir': '/path/to/download_dir',
         'root': '/path/to/root'
@@ -72,6 +74,26 @@ config = {
         'alias_salt': ALIAS_SALT
     },
     'workflow_registry': {
+        'sync_archived_bundles': {
+            'steps': [
+                {
+                    'name': 'archive',
+                    'task': 'archive_dataset'
+                },
+                {
+                    'name': 'stage',
+                    'task': 'stage_dataset'
+                },
+                {
+                    'name': 'validate',
+                    'task': 'validate_dataset'
+                },
+                {
+                    'name': 'setup_download',
+                    'task': 'setup_dataset_download'
+                }
+            ]
+        },
         'integrated': {
             'steps': [
                 {

--- a/workers/workers/dataset.py
+++ b/workers/workers/dataset.py
@@ -33,3 +33,13 @@ def compute_staging_path(dataset: dict) -> tuple[Path, str]:
     staging_dir = Path(config['paths'][dataset_type]['stage']).resolve()
     alias = glom(dataset, 'metadata.stage_alias', default=stage_alias(dataset))
     return staging_dir / alias / dataset['name'], alias
+
+
+def bundle_alias(bundle: dict) -> str:
+    salt = config['stage']['alias_salt']
+    return deterministic_uuid(f'{bundle["id"]}{bundle["name"]}{salt}')
+
+
+def compute_bundle_path(dataset: dict) -> str:
+    alias = glom(dataset, 'metadata.bundle_alias', default=bundle_alias(dataset['bundle']))
+    return alias

--- a/workers/workers/scripts/populate_bundles.py
+++ b/workers/workers/scripts/populate_bundles.py
@@ -1,0 +1,89 @@
+import logging
+from pathlib import Path
+from sca_rhythm import Workflow
+
+from workers.celery_app import app as celery_app
+import workers.sda as sda
+import workers.api as api
+import workers.cmd as cmd
+import workers.workflow_utils as wf_utils
+import workers.utils as utils
+from workers.config import config
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def download_and_validate(dataset: dict) -> bool:
+    logger.info(f'processing dataset {dataset["id"]}')
+
+    bundle_download_path = Path(f'{config["paths"][dataset["type"]]["bundle"]}/{dataset["name"]}.tar')
+    # delete pre-existing bundles to force reevaluation of bundle metadata in the archive step
+    if bundle_download_path.exists():
+        logger.info(f'deleting pre-existing bundle {bundle_download_path}')
+        bundle_download_path.unlink()
+
+    sda_archive_path = dataset['archive_path']
+    try:
+        wf_utils.download_file_from_sda(sda_file_path=sda_archive_path,
+                                        local_file_path=bundle_download_path,
+                                        celery_task=None)
+    except Exception as err:
+        logger.info(f'Encountered exception while downloading dataset {dataset["id"]}:')
+        logger.info(err)
+        return False
+
+    logger.info(f'downloaded dataset {dataset["id"]}')
+
+    sda_archive_checksum = None
+    try:
+        sda_archive_checksum = sda.get_hash(dataset['archive_path'])
+        logger.info(f'sda_archive_checksum: {sda_archive_checksum}')
+    except cmd.SubprocessError as err:
+        logger.info(f'Encountered exception while retrieving SDA checksum of dataset {dataset["id"]}:')
+        logger.info(err)
+        return False
+
+    calculated_checksum = utils.checksum(Path(bundle_download_path))
+    logger.info(f'calculated_checksum: {calculated_checksum}')
+    if sda_archive_checksum != calculated_checksum:
+        logger.info('SDA checksum mismatch for dataset %s', dataset['id'])
+        return False
+
+    logger.info(f'successfully finished processing dataset {dataset["id"]}')
+    return True
+
+
+def main():
+    archived_datasets = api.get_all_datasets(archived=True)
+
+    unprocessed = []
+    for dataset in archived_datasets:
+        download_validated = False
+
+        try:
+            download_validated = download_and_validate(dataset)
+            logger.info(f'download_validated for {dataset["id"]}: {download_validated}')
+        except Exception as err:
+            logger.info(f'failed to download or validate dataset {dataset["id"]}')
+            logger.info(err)
+
+        if download_validated:
+            run_workflows(dataset)
+        else:
+            unprocessed.append(dataset['id'])
+
+    logger.info(f'unprocessed datasets: {unprocessed}')
+
+
+def run_workflows(dataset):
+    dataset_id = dataset['id']
+    wf_body = wf_utils.get_wf_body(wf_name='sync_archived_bundles')
+    wf = Workflow(celery_app=celery_app, **wf_body)
+    api.add_workflow_to_dataset(dataset_id=dataset_id, workflow_id=wf.workflow['_id'])
+    wf.start(dataset_id)
+    logger.info(f'started sync_archived_bundles for {dataset["id"]}, workflow_id: {wf.workflow["_id"]}')
+
+
+if __name__ == '__main__':
+    main()

--- a/workers/workers/scripts/purge_staged_datasets.py
+++ b/workers/workers/scripts/purge_staged_datasets.py
@@ -13,7 +13,7 @@ MAX_PURGES = config['stage']['purge']['max_purges']
 
 
 def main():
-    datasets = api.get_all_datasets(days_since_last_staged=config['stage']['purge']['days_to_live'])
+    datasets = api.get_all_datasets(days_since_last_staged=config['stage']['purge']['days_to_live'], bundle=True)
 
     if len(datasets) > MAX_PURGES:
         logger.warning(
@@ -26,9 +26,8 @@ def main():
     }
     for dataset in datasets[:MAX_PURGES]:
         try:
-            # staged_dataset_path.parent = the alias sub-directory
             staged_path = Path(dataset['staged_path'])
-            bundle_path = Path(f'{str(staged_path.parent)}/{dataset["name"]}.tar')
+            bundle_path = Path(f'{dataset["bundle"]["path"]}')
 
             if staged_path.exists():
                 shutil.rmtree(staged_path)

--- a/workers/workers/tasks/archive.py
+++ b/workers/workers/tasks/archive.py
@@ -1,12 +1,14 @@
+import shutil
 from pathlib import Path
-
 from celery import Celery
 from celery.utils.log import get_task_logger
 from sca_rhythm import WorkflowTask
+import json
 
 import workers.api as api
 import workers.cmd as cmd
 import workers.config.celeryconfig as celeryconfig
+import workers.utils as utils
 import workers.workflow_utils as wf_utils
 from workers.config import config
 
@@ -44,33 +46,43 @@ def make_tarfile(celery_task: WorkflowTask, tar_path: Path, source_dir: str, sou
 
 def archive(celery_task: WorkflowTask, dataset: dict, delete_local_file: bool = False):
     # Tar the dataset directory and compute checksum
-    scratch_tar_path = Path(f'{config["paths"]["scratch"]}/{dataset["name"]}.tar')
+    bundle = Path(f'{config["paths"][dataset["type"]]["bundle"]}/{dataset["name"]}.tar')
 
     make_tarfile(celery_task=celery_task,
-                 tar_path=scratch_tar_path,
+                 tar_path=bundle,
                  source_dir=dataset['origin_path'],
                  source_size=dataset['du_size'])
 
+    bundle_size = bundle.stat().st_size
+    bundle_checksum = utils.checksum(bundle)
+    bundle_attrs = {
+        'name': bundle.name,
+        'path': str(bundle),
+        'size': bundle_size,
+        'md5': bundle_checksum,
+    }
+
     sda_dir = wf_utils.get_archive_dir(dataset['type'])
-    sda_tar_path = f'{sda_dir}/{scratch_tar_path.name}'
-    wf_utils.upload_file_to_sda(local_file_path=scratch_tar_path,
-                                sda_file_path=sda_tar_path,
+    sda_bundle_path = f'{sda_dir}/{bundle.name}'
+
+    wf_utils.upload_file_to_sda(local_file_path=bundle,
+                                sda_file_path=sda_bundle_path,
                                 celery_task=celery_task)
 
-    bundle_size = scratch_tar_path.stat().st_size
     if delete_local_file:
         # file successfully uploaded to SDA, delete the local copy
-        scratch_tar_path.unlink()
+        print("deleting local bundle")
+        bundle.unlink()
 
-    return sda_tar_path, bundle_size
+    return sda_bundle_path, bundle_attrs
 
 
 def archive_dataset(celery_task, dataset_id, **kwargs):
-    dataset = api.get_dataset(dataset_id=dataset_id)
-    sda_tar_path, bundle_size = archive(celery_task, dataset)
+    dataset = api.get_dataset(dataset_id=dataset_id, bundle=True)
+    sda_bundle_path, bundle_attrs = archive(celery_task, dataset)
     update_data = {
-        'archive_path': sda_tar_path,
-        'bundle_size': bundle_size
+        'archive_path': sda_bundle_path,
+        'bundle': bundle_attrs
     }
     api.update_dataset(dataset_id=dataset_id, update_data=update_data)
     api.add_state_to_dataset(dataset_id=dataset_id, state='ARCHIVED')

--- a/workers/workers/tasks/download.py
+++ b/workers/workers/tasks/download.py
@@ -42,28 +42,30 @@ def grant_access_to_parent_chain(leaf: Path, root: Path):
 
 
 def setup_download(celery_task, dataset_id, **kwargs):
-    dataset = api.get_dataset(dataset_id=dataset_id)
+    dataset = api.get_dataset(dataset_id=dataset_id, bundle=True)
     staged_path, alias = Path(dataset['staged_path']), glom(dataset, 'metadata.stage_alias')
-    # staged_path.parent = the alias sub-directory
-    bundle_path = Path(f'{str(staged_path.parent)}/{dataset["name"]}.tar')
+
+    bundle_path = Path(dataset['bundle']['path'])
+    bundle_alias = dataset['metadata']['bundle_alias']
 
     if not staged_path.exists():
         # TODO: more robust validation?
         raise ValidationFailed(f'Staged path does not exist {staged_path}')
 
-    download_path = Path(config['paths']['download_dir']).resolve() / alias
-    tar_download_path = download_path / f"{dataset['name']}.tar"
+    download_dir = Path(config['paths']['download_dir']).resolve()
+    download_path = download_dir / alias
+    bundle_download_path = download_dir / bundle_alias
 
     # remove if exists and create a symlink in download dir pointing to the staged path
     rm(download_path)
     download_path.symlink_to(staged_path, target_is_directory=True)
-    # do the same for tar file
-    rm(tar_download_path)
-    tar_download_path.symlink_to(bundle_path)
+    # do the same for bundle file
+    rm(bundle_download_path)
+    bundle_download_path.symlink_to(bundle_path)
 
     # enable others to read and cd into stage directory
     grant_read_permissions_to_others(staged_path)
-    grant_read_permissions_to_others(tar_download_path)
+    grant_read_permissions_to_others(bundle_download_path)
 
     # enable others to navigate to leaf by granting execute permission on parent directories
     grant_access_to_parent_chain(staged_path, root=Path(config['paths']['root']))

--- a/workers/workers/tasks/mark_archived_and_delete.py
+++ b/workers/workers/tasks/mark_archived_and_delete.py
@@ -10,10 +10,8 @@ def mark_archived_and_delete(celery_task, dataset_id, **kwargs):
     bundle = Path(dataset['bundle']['path'])
 
     sda_tar_path = f'archive/2023/raw_data/{dataset["name"]}.tar'
-    bundle_size = bundle.stat().st_size
     update_data = {
-        'archive_path': sda_tar_path,
-        'bundle_size': bundle_size
+        'archive_path': sda_tar_path
     }
     api.update_dataset(dataset_id=dataset_id, update_data=update_data)
     api.add_state_to_dataset(dataset_id=dataset_id, state='ARCHIVED')

--- a/workers/workers/tasks/mark_archived_and_delete.py
+++ b/workers/workers/tasks/mark_archived_and_delete.py
@@ -5,12 +5,12 @@ from workers import api
 
 
 def mark_archived_and_delete(celery_task, dataset_id, **kwargs):
-    dataset = api.get_dataset(dataset_id=dataset_id)
+    dataset = api.get_dataset(dataset_id=dataset_id, bundle=True)
     source = Path(dataset['origin_path']).resolve()
-    source_tar = source.parent / f'{dataset["name"]}.tar'
+    bundle = Path(dataset['bundle']['path'])
 
     sda_tar_path = f'archive/2023/raw_data/{dataset["name"]}.tar'
-    bundle_size = source_tar.stat().st_size
+    bundle_size = bundle.stat().st_size
     update_data = {
         'archive_path': sda_tar_path,
         'bundle_size': bundle_size
@@ -19,7 +19,7 @@ def mark_archived_and_delete(celery_task, dataset_id, **kwargs):
     api.add_state_to_dataset(dataset_id=dataset_id, state='ARCHIVED')
 
     # delete tar file
-    source_tar.unlink(missing_ok=True)
+    bundle.unlink(missing_ok=True)
 
     # delete source directory
     shutil.rmtree(source, ignore_errors=True)

--- a/workers/workers/tasks/stage.py
+++ b/workers/workers/tasks/stage.py
@@ -9,9 +9,13 @@ from celery.utils.log import get_task_logger
 from sca_rhythm import WorkflowTask
 
 import workers.api as api
+import workers.utils as utils
+from workers.config import config
 import workers.config.celeryconfig as celeryconfig
 import workers.workflow_utils as wf_utils
 from workers.dataset import compute_staging_path
+from workers.dataset import compute_bundle_path
+from workers import exceptions as exc
 
 app = Celery("tasks")
 app.config_from_object(celeryconfig)
@@ -62,33 +66,44 @@ def stage(celery_task: WorkflowTask, dataset: dict) -> (str, str):
     returns: stage_path
     """
     staging_dir, alias = compute_staging_path(dataset)
+    bundle_alias = compute_bundle_path(dataset)
 
-    sda_tar_path = dataset['archive_path']
+    sda_bundle_path = dataset['archive_path']
     alias_dir = staging_dir.parent
     alias_dir.mkdir(parents=True, exist_ok=True)
-    bundle_path = Path(f'{str(alias_dir)}/{dataset["name"]}.tar')
-    wf_utils.download_file_from_sda(sda_file_path=sda_tar_path,
-                                    local_file_path=bundle_path,
+
+    bundle = dataset["bundle"]
+    bundle_md5 = bundle["md5"]
+    bundle_download_path = Path(bundle["path"])
+
+    wf_utils.download_file_from_sda(sda_file_path=sda_bundle_path,
+                                    local_file_path=bundle_download_path,
                                     celery_task=celery_task)
 
+    evaluated_checksum = utils.checksum(bundle_download_path)
+    if evaluated_checksum != bundle_md5:
+        raise exc.ValidationFailed(f'Expected checksum of downloaded file to be {bundle_md5},'
+                                   f' but evaluated checksum was {evaluated_checksum}')
+
     # extract the tar file to stage directory
-    logger.info(f'extracting tar {bundle_path} to {staging_dir}')
-    extract_tarfile(tar_path=bundle_path, target_dir=staging_dir, override_arcname=True)
+    logger.info(f'extracting tar {bundle_download_path} to {staging_dir}')
+    extract_tarfile(tar_path=bundle_download_path, target_dir=staging_dir, override_arcname=True)
 
     # delete the local tar copy after extraction
     # bundle_path.unlink()
 
-    return str(staging_dir), alias
+    return str(staging_dir), alias, bundle_alias
 
 
 def stage_dataset(celery_task, dataset_id, **kwargs):
-    dataset = api.get_dataset(dataset_id=dataset_id)
-    staged_path, alias = stage(celery_task, dataset)
+    dataset = api.get_dataset(dataset_id=dataset_id, bundle=True)
+    staged_path, alias, bundle_alias = stage(celery_task, dataset)
 
     update_data = {
         'staged_path': staged_path,
         'metadata': {
-            'stage_alias': alias
+            'stage_alias': alias,
+            'bundle_alias': bundle_alias
         }
     }
     api.update_dataset(dataset_id=dataset_id, update_data=update_data)

--- a/workers/workers/tasks/validate.py
+++ b/workers/workers/tasks/validate.py
@@ -33,6 +33,7 @@ def check_files(celery_task: WorkflowTask, dataset_dir: Path, files_metadata: li
 def validate_dataset(celery_task, dataset_id, **kwargs):
     dataset = api.get_dataset(dataset_id=dataset_id, files=True)
     staged_path = Path(dataset['staged_path'])
+
     validation_errors = check_files(celery_task=celery_task,
                                     dataset_dir=staged_path,
                                     files_metadata=dataset['files'])


### PR DESCRIPTION
**Description**

Persist bundle metadata in separate table.

**Related Issue(s)**

Closes #102, possibly #37 as well.

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [x] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [x] Documentation updated
- [ ] Other changes: [describe]

**Checklist**

Before submitting this PR, please make sure that:

- [x] Your code passes linting and coding style checks.
- [x] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [x] Any relevant issue(s) have been linked to this PR.

**Additional Information**
- Added separate table for bundle metadata (`bundle`). This is linked to `dataset` via `dataset_id`.
- Archive step is updated to evaluate bundle metadata (path, checksum, etc.), create the bundle record, and associate it with the corresponding dataset.
- Stage step is updated to verify that the checksum of the downloaded bundle is the same as the checksum that the Archive step persisted to the database (this was the requirement for ticket #37).
- Download step is updated to create a symlink for the bundle download.
- All places in the code that were using `dataset.bundle_size` have been updated to use the size from the new `bundle` table.
- A new alias `bundle_alias` is used to obfuscate the actual location of the bundle on Slate-scratch. I am not reusing the `stage_alias` for this because the stage_alias directory symlinks to the top-level directory inside dataset, instead of the dataset's directory. Therefore downloading the staged dataset with this approach would end up having the bundle inside the dataset. This is the alias provided to users who attempt to download bundles.
- Added new paths for staging bundles

I have also added a new script (`populate_bundles.py`) that
- iterates through the currently archived datasets
- downloads them from the SDA
- verifies that the calculated checksum of each downloaded bundle is the same as its checksum retrieved (using the `hsi` utility) from SDA.
- If checksum validation passes, it runs the `sync_archived_bundles` workflow on these datasets, which runs the tasks archive (which populates the bundle metadata in the `bundle` table), stage, validate, and setup_download steps on each of them, thus preparing them for download.