### PR TITLE
disable auto population of bundles upon pm2 restart

### DIFF
--- a/workers/ecosystem.config.js
+++ b/workers/ecosystem.config.js
@@ -69,16 +69,16 @@ module.exports = {
       exp_backoff_restart_delay: 100,
       max_restarts: 3,
     },
-    {
-      name: "populate_bundles",
-      script: "python",
-      args: "-u -m workers.scripts.populate_bundles",
-      watch: false,
-      interpreter: "",
-      log_date_format: "YYYY-MM-DD HH:mm Z",
-      error_file: "../logs/workers/populate_bundles.err",
-      out_file: "../logs/workers/populate_bundles.log",
-      autorestart: false,
-    }
+    // {
+    //   name: "populate_bundles",
+    //   script: "python",
+    //   args: "-u -m workers.scripts.populate_bundles",
+    //   watch: false,
+    //   interpreter: "",
+    //   log_date_format: "YYYY-MM-DD HH:mm Z",
+    //   error_file: "../logs/workers/populate_bundles.err",
+    //   out_file: "../logs/workers/populate_bundles.log",
+    //   autorestart: false,
+    // }
   ]
 }


### PR DESCRIPTION
There is no need to have this script run every time a Bioloop instance is deployed. This is a one-time script that should run on demand.