### PR TITLE
make bundle workflows agnostic of filesystem path

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -104,7 +104,6 @@ model bundle {
   id         Int      @id @default(autoincrement())
   created_at DateTime @default(now()) @db.Timestamp(6)
   name       String
-  path       String
   size       BigInt?
   md5        String
   dataset_id Int      @unique

--- a/workers/workers/config/common.py
+++ b/workers/workers/config/common.py
@@ -40,13 +40,19 @@ config = {
         'RAW_DATA': {
             'archive': f'development/{YEAR}/raw_data',
             'stage': '/path/to/staged/raw_data',
-            'bundle': '/path/to/bundle/raw_data',
+            'bundle': {
+                'generate': '/path/for/raw_data/bundle/generation',
+                'stage': '/path/for/raw_data/bundle/staging',
+            },
             'qc': '/path/to/qc'
         },
         'DATA_PRODUCT': {
             'archive': f'development/{YEAR}/data_products',
             'stage': '/path/to/staged/data_products',
-            'bundle': '/path/to/bundle/data_products',
+            'bundle': {
+                'generate': '/path/for/data_products/bundle/generation',
+                'stage': '/path/for/data_products/bundle/staging',
+            },
         },
         'download_dir': '/path/to/download_dir',
         'root': '/path/to/root'

--- a/workers/workers/dataset.py
+++ b/workers/workers/dataset.py
@@ -46,4 +46,4 @@ def compute_bundle_path(dataset: dict) -> str:
 
 
 def get_bundle_staged_path(dataset: dict) -> str:
-    Path(f'{config["paths"][dataset["type"]]["bundle"]["stage"]}/{dataset["bundle"]["name"]}')
+    return f'{config["paths"][dataset["type"]]["bundle"]["stage"]}/{dataset["bundle"]["name"]}'

--- a/workers/workers/dataset.py
+++ b/workers/workers/dataset.py
@@ -43,3 +43,7 @@ def bundle_alias(bundle: dict) -> str:
 def compute_bundle_path(dataset: dict) -> str:
     alias = glom(dataset, 'metadata.bundle_alias', default=bundle_alias(dataset['bundle']))
     return alias
+
+
+def get_bundle_staged_path(dataset: dict) -> str:
+    Path(f'{config["paths"][dataset["type"]]["bundle"]["stage"]}/{dataset["bundle"]["name"]}')

--- a/workers/workers/scripts/purge_staged_datasets.py
+++ b/workers/workers/scripts/purge_staged_datasets.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import workers.api as api
 from workers.config import config
+from workers.dataset import get_bundle_staged_path
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ def main():
     for dataset in datasets[:MAX_PURGES]:
         try:
             staged_path = Path(dataset['staged_path'])
-            bundle_path = Path(f'{dataset["bundle"]["path"]}')
+            bundle_path = Path(get_bundle_staged_path(dataset=dataset)
 
             if staged_path.exists():
                 shutil.rmtree(staged_path)

--- a/workers/workers/tasks/archive.py
+++ b/workers/workers/tasks/archive.py
@@ -46,7 +46,7 @@ def make_tarfile(celery_task: WorkflowTask, tar_path: Path, source_dir: str, sou
 
 def archive(celery_task: WorkflowTask, dataset: dict, delete_local_file: bool = False):
     # Tar the dataset directory and compute checksum
-    bundle = Path(f'{config["paths"][dataset["type"]]["bundle"]}/{dataset["name"]}.tar')
+    bundle = Path(f'{config["paths"][dataset["type"]]["bundle"]["generate"]}/{dataset["name"]}.tar')
 
     make_tarfile(celery_task=celery_task,
                  tar_path=bundle,
@@ -57,7 +57,6 @@ def archive(celery_task: WorkflowTask, dataset: dict, delete_local_file: bool = 
     bundle_checksum = utils.checksum(bundle)
     bundle_attrs = {
         'name': bundle.name,
-        'path': str(bundle),
         'size': bundle_size,
         'md5': bundle_checksum,
     }

--- a/workers/workers/tasks/download.py
+++ b/workers/workers/tasks/download.py
@@ -10,6 +10,7 @@ import workers.api as api
 import workers.config.celeryconfig as celeryconfig
 from workers.config import config
 from workers.exceptions import ValidationFailed
+from workers.dataset import get_bundle_staged_path
 
 app = Celery("tasks")
 app.config_from_object(celeryconfig)
@@ -45,7 +46,7 @@ def setup_download(celery_task, dataset_id, **kwargs):
     dataset = api.get_dataset(dataset_id=dataset_id, bundle=True)
     staged_path, alias = Path(dataset['staged_path']), glom(dataset, 'metadata.stage_alias')
 
-    bundle_path = Path(dataset['bundle']['path'])
+    bundle_path = Path(get_bundle_staged_path(dataset=dataset)
     bundle_alias = dataset['metadata']['bundle_alias']
 
     if not staged_path.exists():

--- a/workers/workers/tasks/download.py
+++ b/workers/workers/tasks/download.py
@@ -4,6 +4,7 @@ import stat
 from pathlib import Path
 
 from celery import Celery
+from celery.utils.log import get_task_logger
 from glom import glom
 
 import workers.api as api
@@ -14,6 +15,7 @@ from workers.dataset import get_bundle_staged_path
 
 app = Celery("tasks")
 app.config_from_object(celeryconfig)
+logger = get_task_logger(__name__)
 
 
 def rm(p: Path):
@@ -46,7 +48,8 @@ def setup_download(celery_task, dataset_id, **kwargs):
     dataset = api.get_dataset(dataset_id=dataset_id, bundle=True)
     staged_path, alias = Path(dataset['staged_path']), glom(dataset, 'metadata.stage_alias')
 
-    bundle_path = Path(get_bundle_staged_path(dataset=dataset)
+    bundle_path = Path(get_bundle_staged_path(dataset=dataset))
+
     bundle_alias = dataset['metadata']['bundle_alias']
 
     if not staged_path.exists():

--- a/workers/workers/tasks/mark_archived_and_delete.py
+++ b/workers/workers/tasks/mark_archived_and_delete.py
@@ -2,12 +2,13 @@ import shutil
 from pathlib import Path
 
 from workers import api
+from workers.dataset import get_bundle_staged_path
 
 
 def mark_archived_and_delete(celery_task, dataset_id, **kwargs):
     dataset = api.get_dataset(dataset_id=dataset_id, bundle=True)
     source = Path(dataset['origin_path']).resolve()
-    bundle = Path(dataset['bundle']['path'])
+    bundle_path = Path(get_bundle_staged_path(dataset=dataset)
 
     sda_tar_path = f'archive/2023/raw_data/{dataset["name"]}.tar'
     update_data = {
@@ -17,7 +18,7 @@ def mark_archived_and_delete(celery_task, dataset_id, **kwargs):
     api.add_state_to_dataset(dataset_id=dataset_id, state='ARCHIVED')
 
     # delete tar file
-    bundle.unlink(missing_ok=True)
+    bundle_path.unlink(missing_ok=True)
 
     # delete source directory
     shutil.rmtree(source, ignore_errors=True)

--- a/workers/workers/tasks/stage.py
+++ b/workers/workers/tasks/stage.py
@@ -14,7 +14,7 @@ from workers.config import config
 import workers.config.celeryconfig as celeryconfig
 import workers.workflow_utils as wf_utils
 from workers.dataset import compute_staging_path
-from workers.dataset import compute_bundle_path
+from workers.dataset import compute_bundle_path, get_bundle_staged_path
 from workers import exceptions as exc
 
 app = Celery("tasks")
@@ -74,7 +74,7 @@ def stage(celery_task: WorkflowTask, dataset: dict) -> (str, str):
 
     bundle = dataset["bundle"]
     bundle_md5 = bundle["md5"]
-    bundle_download_path = Path(bundle["path"])
+    bundle_download_path = Path(get_bundle_staged_path(dataset=dataset))
 
     wf_utils.download_file_from_sda(sda_file_path=sda_bundle_path,
                                     local_file_path=bundle_download_path,

--- a/workers/workers/utils.py
+++ b/workers/workers/utils.py
@@ -9,6 +9,7 @@ from enum import Enum, unique
 from itertools import islice
 from pathlib import Path
 
+from workers.config import config
 
 def str_func_call(func, args, kwargs):
     args_list = [repr(arg) for arg in args] + [f"{key}={repr(val)}" for key, val in kwargs.items()]

--- a/workers/workers/utils.py
+++ b/workers/workers/utils.py
@@ -9,7 +9,6 @@ from enum import Enum, unique
 from itertools import islice
 from pathlib import Path
 
-from workers.config import config
 
 def str_func_call(func, args, kwargs):
     args_list = [repr(arg) for arg in args] + [f"{key}={repr(val)}" for key, val in kwargs.items()]


### PR DESCRIPTION
**Description**

Don't persist staging path of dataset bundles in the database.

**Related Issue(s)**

Closes #205 

If applicable, please reference the issue(s) that this PR addresses. If the PR does not address any specific issue, you can remove this section.

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [ ] Feature added
- [x] Bug fixed
- [x] Code refactored
- [x] Documentation updated
- [ ] Other changes: [describe]

**Screenshots (if applicable)**

Provide screenshots or GIFs that visually represent the changes. If not applicable, you can remove this section.

**Checklist**

Before submitting this PR, please make sure that:

- [x] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [x] Any relevant issue(s) have been linked to this PR.

**Additional Information**

Bundle paths are being not being persisted in the database anymore. There are two config paths instead - one for staging, and another for generating bundles.
