### PR TITLE
fix: Add include_projects query parameter to dataset routes to send project assignor information

### DIFF
--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -302,6 +302,7 @@ router.get(
     query('prev_task_runs').toBoolean().default(false),
     query('only_active').toBoolean().default(false),
     query('bundle').optional().toBoolean(),
+    query('include_projects').optional().toBoolean(),
   ]),
   dataset_access_check,
   asyncHandler(async (req, res, next) => {
@@ -316,6 +317,7 @@ router.get(
       prev_task_runs: req.query.prev_task_runs,
       only_active: req.query.only_active,
       bundle: req.query.bundle || false,
+      includeProjects: req.query.include_projects || false,
     });
     res.json(dataset);
   }),

--- a/api/src/services/dataset.js
+++ b/api/src/services/dataset.js
@@ -130,6 +130,7 @@ async function get_dataset({
   prev_task_runs = false,
   only_active = false,
   bundle = false,
+  includeProjects = false,
 }) {
   const fileSelect = files ? {
     select: {
@@ -153,6 +154,7 @@ async function get_dataset({
       bundle,
       source_datasets: true,
       derived_datasets: true,
+      projects: includeProjects,
     },
   });
 

--- a/ui/src/components/project/datasets/ProjectDatasetsTable.vue
+++ b/ui/src/components/project/datasets/ProjectDatasetsTable.vue
@@ -328,7 +328,7 @@ const tracking = computed(() => {
 
 function fetch_and_update_dataset(id) {
   // console.log("fetch_and_update_dataset", id);
-  DatasetService.getById({ id })
+  DatasetService.getById({ id, include_projects: true })
     .then((res) => {
       _datasets.value[id] = res.data;
     })
@@ -439,6 +439,6 @@ function openModalToStageProject(dataset) {
 }
 
 function getCurrentProjAssoc(assocs) {
-  return assocs.filter((obj) => obj.project_id === props.project.id)[0];
+  return assocs?.filter((obj) => obj.project_id === props.project.id)?.[0];
 }
 </script>

--- a/ui/src/services/dataset.js
+++ b/ui/src/services/dataset.js
@@ -33,6 +33,7 @@ class DatasetService {
     prev_task_runs = false,
     only_active = false,
     bundle = false,
+    include_projects = false,
   }) {
     return api.get(`/datasets/${id}`, {
       params: {
@@ -42,6 +43,7 @@ class DatasetService {
         prev_task_runs,
         only_active,
         bundle,
+        include_projects,
       },
     });
   }


### PR DESCRIPTION
While staging a dataset from the project page, polling service fetches the dataset by id and updates the UI. This API call should include the project assignor information as well.