### PR TITLE
Update dir_last_modified_time function to consider both c_time and m_time for last modified time calculation

### DIFF
--- a/workers/workers/tasks/await_stability.py
+++ b/workers/workers/tasks/await_stability.py
@@ -22,6 +22,12 @@ def dir_last_modified_time(dataset_path: Path) -> float:
     At times, when copying files, outdated modification times may be retained.
     To address this, monitor the modification time of the root directory as well.
 
+    If the copy process is configured to preserve the metadata of the source file, it will update the m_time
+    of the target file after the copy process. This will update the c_time of the target file. In these cases,
+    c_time will be bigger than m_time. So, we will consider the maximum of c_time and m_time of the file / directory 
+    as the last modified time.
+
+
     Args:
     dataset_path (Path): Path object to the directory.
 
@@ -29,7 +35,10 @@ def dir_last_modified_time(dataset_path: Path) -> float:
     float: The last modified time in epoch seconds.
     """
     paths = itertools.chain([dataset_path], dataset_path.rglob('*'))
-    return max((p.lstat().st_mtime for p in paths if p.exists()), default=time.time())
+    return max(
+        (max(p.lstat().st_mtime, p.lstat().st_ctime) for p in paths if p.exists()),
+        default=time.time()
+    )
 
 
 def update_progress(celery_task, mod_time, delta):


### PR DESCRIPTION
If the copy process is configured to preserve the metadata of the source file, it will set the m_time
of the target file after the copy process. This will update the c_time of the target file. In these cases,
c_time will be bigger than m_time. So, we will consider the maximum of c_time and m_time of the file / directory 
as the last modified time.