### PR TITLE
Add pagination with search and sort functionality (user page)

### DIFF
--- a/api/src/services/user.js
+++ b/api/src/services/user.js
@@ -1,4 +1,4 @@
-const { PrismaClient } = require('@prisma/client');
+const { Prisma, PrismaClient } = require('@prisma/client');
 const _ = require('lodash/fp');
 
 const prisma = new PrismaClient();
@@ -84,12 +84,37 @@ async function updateLastLogin({ id, method }) {
   });
 }
 
-async function findAll(sort) {
-  const users = await prisma.user.findMany({
-    include: INCLUDE_ROLES_LOGIN,
-    orderBy: sort.map(({ key, dir }) => ({ [key]: dir })),
-  });
-  return users.map(transformUser);
+async function findAll({
+  search, sortBy, sort_order, skip, take,
+}) {
+  const sort_sql = Prisma.raw(`"${sortBy}" ${sort_order}`);
+  const sql = Prisma.sql`
+  with results as (
+      select u.*, ul.last_login, ul."method", array_agg(r."name") as roles from "user" u
+      left join user_login ul on u.id = ul.user_id
+      left join user_role ur on ur.user_id = u.id
+      left join "role" r on r.id = ur.role_id
+      where u."name" ilike ${`%${search}%`} or u."email" ilike ${`%${search}%`} or u."username" ilike ${`%${search}%`}
+      group by u.id, ul.last_login, ul."method"
+    )
+    select *, count(*) over() as total_count from results
+    order by ${sort_sql} nulls last
+    ${take !== undefined ? Prisma.sql`limit ${take}  offset ${skip}` : Prisma.empty}
+  `;
+
+  const users = await prisma.$queryRaw(sql);
+  const total_count = Number(users.length ? users[0].total_count : 0);
+
+  return {
+    count: total_count,
+    users: users.map(({ last_login, method, ...rest }) => ({
+      ...rest,
+      login: {
+        last_login,
+        method,
+      },
+    })),
+  };
 }
 
 async function createUser(data) {

--- a/ui/src/services/user.js
+++ b/ui/src/services/user.js
@@ -1,8 +1,21 @@
 import api from "./api";
 
 class UserService {
-  getAll() {
-    return api.get("/users").then((response) => response.data);
+  getAll({ search = "", sortBy, sort_order, skip = 0, take = 10 }) {
+    return api
+      .get("/users", {
+        params: {
+          search,
+          sortBy,
+          sort_order,
+          skip,
+          take,
+        },
+      })
+      .then((response) => {
+        const { metadata, users } = response.data;
+        return { metadata, users };
+      });
   }
 
   createUser(user_data) {


### PR DESCRIPTION

**Description**

1.) Server-side pagination to "users page" with options for how many items to display per page (25, 50, 100), along with the range of items on a page, and the total count of items.

2.) The search functionality dynamically filters the list of users based on a search query.

3.) The sort functionality enables users to order the list of users by specific attributes (name, username, email, created_on, status, last_login, auth) in either ascending or descending order.

**Related Issue(s)**

Closes #242

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Screenshots (if applicable)**

![Pagination](https://github.com/user-attachments/assets/c66f5a6e-26d9-44b4-b8b7-75014af1ea96)

![Sorting](https://github.com/user-attachments/assets/0fb8d7c0-f65e-45b0-899d-4ec1691f39f6)

![Search](https://github.com/user-attachments/assets/4ee6183e-cf97-4cf2-804c-28e53b8dae55)


**Checklist**

- [x] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [ ] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.
