### PR TITLE
Add Pagination to projects page with search and sort functionality

### DIFF
--- a/api/src/routes/projects.js
+++ b/api/src/routes/projects.js
@@ -87,15 +87,75 @@ const build_include_object = ({
 router.get(
   '/all',
   isPermittedTo('read'),
+  validate([
+    query('take').isInt().toInt().default(10),
+    query('skip').isInt().toInt().default(0),
+    query('search').optional().isString(),
+    query('sort_order').optional().isString().default('asc'),
+    query('sort_by').default('name').isIn(['name', 'created_at', 'updated_at']),
+  ]),
   asyncHandler(async (req, res, next) => {
-    // #swagger.tags = ['Projects']
-    // #swagger.summary = get all projects.
-    // #swagger.description = admin and operator roles are allowed and user role is forbidden
-    const projects = await prisma.project.findMany({
-      where: {},
-      include: build_include_object(),
+    const { search, sort_order, sort_by } = req.query;
+
+    const filters = search
+      ? {
+        OR: [
+          {
+            name: {
+              contains: search,
+              mode: 'insensitive', // Case-insensitive search
+            },
+          },
+          {
+            users: {
+              some: {
+                user: {
+                  username: {
+                    contains: search,
+                    mode: 'insensitive',
+                  },
+                },
+              },
+            },
+          },
+          {
+            datasets: {
+              some: {
+                dataset: {
+                  name: {
+                    contains: search,
+                    mode: 'insensitive',
+                  },
+                },
+              },
+            },
+          },
+        ],
+
+      }
+      : {};
+
+    const sort_obj = {
+      [sort_by]: sort_order, // Sort by 'Name' column in the specified order
+    };
+
+    const [projects, totalCount] = await prisma.$transaction([
+      prisma.project.findMany({
+        skip: req.query.skip,
+        take: req.query.take,
+        orderBy: sort_obj,
+        where: filters,
+        include: build_include_object(),
+      }),
+      prisma.project.count({
+        where: filters,
+      }), // Count all projects to get total number
+    ]);
+
+    res.json({
+      metadata: { count: totalCount },
+      projects,
     });
-    res.json(projects);
   }),
 );
 
@@ -159,8 +219,8 @@ router.get(
   validate([
     param('username').notEmpty().escape(),
     query('staged').toBoolean().optional(),
-    query('limit').isInt().toInt().optional(),
-    query('offset').isInt().toInt().optional(),
+    query('take').isInt().toInt().optional(),
+    query('skip').isInt().toInt().optional(),
     query('name').notEmpty().escape().optional(),
     query('sortBy').isObject().optional(),
   ]),
@@ -210,8 +270,8 @@ router.get(
 
     const filterQuery = { where: query_obj };
     const datasetRetrievalQuery = {
-      skip: req.query.offset,
-      take: req.query.limit,
+      skip: req.query.skip,
+      take: req.query.take,
       ...filterQuery,
       orderBy: buildOrderByObject(Object.keys(sortBy)[0], Object.values(sortBy)[0]),
       include: {
@@ -280,26 +340,102 @@ const buildOrderByObject = (field, sortOrder, nullsLast = true) => {
 router.get(
   '/:username/all',
   isPermittedTo('read', { checkOwnerShip: true }),
+  validate([
+    query('take').isInt().toInt().default(10),
+    query('skip').isInt().toInt().default(0),
+    query('search').optional().isString(), // Adding search query validation
+    query('sort_order').optional().isString().default('asc'),
+    query('sort_by').default('name').isIn(['name', 'created_at', 'updated_at']),
+  ]),
   asyncHandler(async (req, res, next) => {
     // #swagger.tags = ['Projects']
-    // #swagger.summary = get all projects associated with a username
+    // #swagger.summary = get all projects associated with a username with pagination.
     /* #swagger.description = user role: can only see their projects.
       operator, admin: can see anyone's projects
     */
-    const projects = await prisma.project.findMany({
-      where: {
+    const { search, sort_order, sort_by } = req.query;
+    const { username } = req.params;
+
+    const filters = search
+      ? {
+        AND: [
+          {
+            users: {
+              some: {
+                user: {
+                  username,
+                },
+              },
+            },
+          },
+          {
+            OR: [
+              {
+                name: {
+                  contains: search,
+                  mode: 'insensitive',
+                },
+              },
+              {
+                datasets: {
+                  some: {
+                    dataset: {
+                      name: {
+                        contains: search,
+                        mode: 'insensitive',
+                      },
+                    },
+                  },
+                },
+              },
+              {
+                users: {
+                  some: {
+                    user: {
+                      username: {
+                        contains: search,
+                        mode: 'insensitive',
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      }
+      : {
         users: {
           some: {
             user: {
-              username: req.params.username,
+              username,
             },
           },
         },
-      },
-      include: build_include_object(),
+      };
+
+    const sort_obj = {
+      [sort_by]: sort_order, // Sort by 'Name' column in the specified order
+    };
+
+    // Query to get paginated projects associated with the username
+    const [projects, totalCount] = await prisma.$transaction([
+      prisma.project.findMany({
+        where: filters,
+        skip: req.query.skip,
+        take: req.query.take,
+        orderBy: sort_obj,
+        include: build_include_object(),
+      }),
+      prisma.project.count({
+        where: filters, // Apply the search filters to the count as well
+      }),
+    ]);
+
+    res.json({
+      metadata: { count: totalCount },
+      projects: projects.map((p) => req.permission.filter(p)),
     });
-    // don't know why projects.map(req.permission.filter) wouldn't work
-    res.json(projects.map((p) => req.permission.filter(p)));
   }),
 );
 

--- a/api/src/routes/users.js
+++ b/api/src/routes/users.js
@@ -5,7 +5,7 @@ const { PrismaClient } = require('@prisma/client');
 
 // const logger = require('../services/logger');
 const userService = require('../services/user');
-const { validate, addSortSantizer } = require('../middleware/validators');
+const { validate } = require('../middleware/validators');
 const asyncHandler = require('../middleware/asyncHandler');
 const { accessControl } = require('../middleware/auth');
 
@@ -28,13 +28,30 @@ router.get(
   '/',
   isPermittedTo('read'),
   validate([
-    addSortSantizer(query('sort').default('username:asc')),
+    query('text').isString().default(''),
+    query('skip').isInt({ min: 0 }).default(0),
+    query('take').isInt({ min: 1 }).default(25),
+    query('sort_by')
+      .isIn(['name', 'username', 'email', 'created_at', 'last_login', 'login_method', 'is_deleted'])
+      .default('username'),
+    query('sort_order').default('asc'),
   ]),
   asyncHandler(async (req, res, next) => {
-    // #swagger.tags = ['Users']
-    const users = await userService.findAll(req.query.sort);
-    return res.json(users);
-    // res.json(req.query.sort);
+    const {
+      text, sort_by, sort_order, skip, take,
+    } = req.query;
+
+    const { users, count } = await userService.findAll({
+      text,
+      sort_by,
+      sort_order,
+      skip: parseInt(skip, 10),
+      take: parseInt(take, 10),
+    });
+    return res.json({
+      metadata: { count },
+      users,
+    });
   }),
 );
 

--- a/ui/src/components/users/UserSelect.vue
+++ b/ui/src/components/users/UserSelect.vue
@@ -28,6 +28,6 @@ const filterFn = (text) => (user) => {
 };
 
 userService.getAll().then((data) => {
-  users.value = data;
+  users.value = data.users;
 });
 </script>

--- a/ui/src/pages/projects/index.vue
+++ b/ui/src/pages/projects/index.vue
@@ -35,8 +35,9 @@
       <va-data-table
         :items="row_items"
         :columns="columns"
-        v-model:sort-by="sortBy"
-        v-model:sorting-order="sortingOrder"
+        v-model:sort-by="params.sortBy"
+        v-model:sorting-order="params.sortingOrder"
+        disable-client-side-sorting
         hoverable
         :loading="data_loading"
       >
@@ -111,6 +112,16 @@
     </div>
   </div>
 
+  <!-- pagination -->
+  <Pagination
+    class="mt-4 px-1 lg:px-3"
+    v-model:page="params.currentPage"
+    v-model:page_size="params.itemsPerPage"
+    :total_results="totalItems"
+    :curr_items="row_items.length"
+    :page_size_options="PAGE_SIZE_OPTIONS"
+  />
+
   <!-- edit modal -->
   <EditProjectInfoModal
     ref="editModal"
@@ -130,6 +141,7 @@
 </template>
 
 <script setup>
+import useQueryPersistence from "@/composables/useQueryPersistence";
 import * as datetime from "@/services/datetime";
 import projectService from "@/services/projects";
 import { useAuthStore } from "@/stores/auth";
@@ -141,47 +153,59 @@ const router = useRouter();
 
 const projects = ref([]);
 const filterInput = ref("");
-const debouncedFilterInput = refDebounced(filterInput, 200);
 const data_loading = ref(false);
+const totalItems = ref(0);
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
 
-// initial sorting order
-const sortBy = ref("updated_at");
-const sortingOrder = ref("desc");
+debouncedWatch(
+  filterInput,
+  () => {
+    params.value.search = filterInput.value;
+  },
+  { debounce: 300 },
+);
+
+function defaultParams() {
+  return {
+    search: "",
+    sortBy: "updated_at",
+    sortingOrder: "desc",
+    currentPage: 1,
+    itemsPerPage: 25,
+  };
+}
+
+const params = ref(defaultParams());
+
+useQueryPersistence({
+  refObject: params,
+  defaultValueFn: defaultParams,
+  key: "q",
+  history_push: true,
+});
 
 const row_items = computed(() => {
-  return projects.value
-    .map((project) => {
-      // eslint-disable-next-line no-unused-vars
-      const { users, contacts, datasets, ...rest } = project;
-      const _users = (users || []).map((obj) => ({
-        id: obj?.user?.id,
-        username: obj?.user?.username,
-      }));
-      // const contact_values = (contacts || []).map(
-      //   (contact) => contact?.contact?.value
-      // );
-      const _datasets = (datasets || []).map((d) => ({
-        id: d?.dataset?.id,
-        name: d?.dataset?.name,
-      }));
-      return {
-        ...rest,
-        users: _users,
-        // contacts: contact_values,
-        datasets: _datasets,
-      };
-    })
-    .filter((row) => {
-      const searchText = debouncedFilterInput.value?.toLowerCase() || "";
-      return (
-        searchText === "" ||
-        customFilteringFn(searchText, {
-          name: row.name,
-          users: row.users,
-          datasets: row.datasets,
-        })
-      );
-    });
+  return projects.value.map((project) => {
+    // eslint-disable-next-line no-unused-vars
+    const { users, contacts, datasets, ...rest } = project;
+    const _users = (users || []).map((obj) => ({
+      id: obj?.user?.id,
+      username: obj?.user?.username,
+    }));
+    // const contact_values = (contacts || []).map(
+    //   (contact) => contact?.contact?.value
+    // );
+    const _datasets = (datasets || []).map((d) => ({
+      id: d?.dataset?.id,
+      name: d?.dataset?.name,
+    }));
+    return {
+      ...rest,
+      users: _users,
+      // contacts: contact_values,
+      datasets: _datasets,
+    };
+  });
 });
 
 // This could've been split into two variables user_columns and admin_columns
@@ -203,27 +227,41 @@ const columns = [
   ...(auth.canOperate ? [{ key: "actions", width: "80px" }] : []),
 ];
 
-function customFilteringFn(searchText, { name, users, datasets }) {
-  return (
-    searchText === "" ||
-    (name || "").toLowerCase().includes(searchText) ||
-    users.some((user) =>
-      (user?.username || "").toLowerCase().includes(searchText),
-    ) ||
-    datasets.some((dataset) =>
-      (dataset?.name || "").toLowerCase().includes(searchText),
-    )
-  );
-}
+// function customFilteringFn(searchText, { name, users, datasets }) {
+//   return (
+//     searchText === "" ||
+//     (name || "").toLowerCase().includes(searchText) ||
+//     users.some((user) =>
+//       (user?.username || "").toLowerCase().includs(searchText),
+//     ) ||
+//     datasets.some((dataset) =>
+//       (dataset?.name || "").toLowerCase().includes(searchText),
+//     )
+//   );
+// }
 
 function fetch_projects() {
   data_loading.value = true;
+
+  const skip = (params.value.currentPage - 1) * params.value.itemsPerPage;
+
+  const queryparams = {
+    forSelf: !auth.canOperate,
+    search: params.value.search,
+    take: params.value.itemsPerPage,
+    skip: skip,
+    sortBy: params.value.sortBy,
+    sort_order: params.value.sortingOrder,
+  };
+
   projectService
-    .getAll({
-      forSelf: !auth.canOperate,
-    })
+    .getAll(queryparams)
     .then((res) => {
-      projects.value = res.data;
+      projects.value = res.data.projects;
+      totalItems.value = res.data.metadata.count;
+    })
+    .catch((error) => {
+      console.log("Error fetching projects:", error);
     })
     .finally(() => {
       data_loading.value = false;
@@ -260,6 +298,28 @@ function openModalToDeleteProject(rowData) {
   selectedForDeletion.value = rowData;
   deleteModal.value.show();
 }
+
+watch(
+  () => params.value.currentPage,
+  () => {
+    fetch_projects();
+  },
+);
+
+watch(
+  [
+    () => params.value.itemsPerPage,
+    () => params.value.search,
+    () => params.value.sortBy,
+    () => params.value.sortingOrder,
+  ],
+  () => {
+    if (params.value.currentPage === 1) {
+      fetch_projects();
+    }
+    params.value.currentPage = 1;
+  },
+);
 </script>
 
 <route lang="yaml">

--- a/ui/src/pages/users.vue
+++ b/ui/src/pages/users.vue
@@ -34,7 +34,9 @@
     class="usertable"
     :items="users"
     :columns="columns"
-    :filter="filterInput"
+    v-model:sort-by="sort_by"
+    v-model:sorting-order="sort_order"
+    disable-client-side-sorting
     :loading="data_loading"
   >
     <!-- roles -->
@@ -67,9 +69,9 @@
       />
     </template>
 
-    <template #cell(login)="{ source }">
-      <span v-if="source?.last_login">
-        {{ datetime.fromNow(source.last_login) }}</span
+    <template #cell(last_login)="{ rowData }">
+      <span v-if="rowData?.login?.last_login">
+        {{ datetime.fromNow(rowData?.login?.last_login) }}</span
       >
     </template>
 
@@ -116,6 +118,16 @@
       </div>
     </template>
   </va-data-table>
+
+  <!-- pagination -->
+  <Pagination
+    class="mt-4 px-1 lg:px-3"
+    v-model:page="currentPage"
+    v-model:page_size="itemsPerPage"
+    :total_results="totalItems"
+    :curr_items="users.length"
+    :page_size_options="PAGE_SIZE_OPTIONS"
+  />
 
   <!-- edit modal -->
   <va-modal
@@ -214,13 +226,19 @@
 import * as datetime from "@/services/datetime";
 import toast from "@/services/toast";
 import UserService from "@/services/user";
-import { cmp } from "@/services/utils";
 import { useAuthStore } from "@/stores/auth";
 
 const auth = useAuthStore();
-
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
 const users = ref([]);
 const filterInput = ref("");
+const debouncedInput = useDebounce(filterInput, 300);
+const currentPage = ref(1);
+const itemsPerPage = ref(25); // Number of items per page
+const totalItems = ref(0);
+const sort_by = ref("name");
+const sort_order = ref("asc");
+
 const editing = ref(false);
 const editedUser = ref({});
 const modifyFormRef = ref(null);
@@ -251,9 +269,9 @@ function get_role_color(role) {
 }
 
 const columns = ref([
-  { key: "name", sortable: true },
-  { key: "username", sortable: true, sortingOptions: ["desc", "asc", null] },
-  { key: "email", sortable: true },
+  { key: "name", sortable: true, sortingOptions: ["asc", "desc", null] },
+  { key: "username", sortable: true, sortingOptions: ["asc", "desc", null] },
+  { key: "email", sortable: true, sortingOptions: ["asc", "desc", null] },
   { key: "roles", sortable: false },
   {
     key: "created_at",
@@ -263,11 +281,10 @@ const columns = ref([
   },
   { key: "is_deleted", sortable: true, label: "status", width: "60px" },
   {
-    key: "login",
+    key: "last_login",
     sortable: true,
     label: "Last Login",
     width: "150px",
-    sortingFn: (a, b) => cmp(a?.last_login, b?.last_login),
   },
   {
     key: "login_method",
@@ -280,9 +297,22 @@ const columns = ref([
 
 function fetch_all_users() {
   data_loading.value = true;
-  UserService.getAll()
-    .then((_users) => {
-      users.value = _users;
+
+  const params = {
+    text: filterInput.value,
+    sort_by: sort_by.value,
+    sort_order: sort_order.value,
+    skip: (currentPage.value - 1) * itemsPerPage.value,
+    take: itemsPerPage.value,
+  };
+
+  console.log("API Request Parameters:", params);
+
+  UserService.getAll(params)
+    .then((data) => {
+      const { metadata, users: userList } = data;
+      users.value = userList;
+      totalItems.value = metadata.count;
     })
     .catch((err) => {
       console.error(err);
@@ -388,6 +418,17 @@ function createUser() {
       });
   }
 }
+
+watch([itemsPerPage, debouncedInput, sort_by, sort_order], () => {
+  if (currentPage.value === 1) {
+    fetch_all_users();
+  }
+  currentPage.value = 1;
+});
+
+watch(currentPage, () => {
+  fetch_all_users();
+});
 
 watch(
   () => editedUser.value.email,

--- a/ui/src/services/projects.js
+++ b/ui/src/services/projects.js
@@ -5,10 +5,20 @@ import api from "./api";
 const auth = useAuthStore();
 
 class projectService {
-  getAll({ forSelf }) {
+  getAll({
+    forSelf,
+    take = 10,
+    skip = 0,
+    search = "",
+    sortBy = "updated_at",
+    sort_order = "asc",
+  } = {}) {
     const username = auth.user.username;
+    const params = { take, skip, search, sortBy, sort_order };
     return (
-      forSelf ? api.get(`/projects/${username}/all`) : api.get("/projects/all")
+      forSelf
+        ? api.get(`/projects/${username}/all`, { params })
+        : api.get("/projects/all", { params })
     ).catch((err) => {
       console.error(err);
       toast.error("Unable to fetch projects");

--- a/ui/src/services/user.js
+++ b/ui/src/services/user.js
@@ -1,8 +1,21 @@
 import api from "./api";
 
 class UserService {
-  getAll() {
-    return api.get("/users").then((response) => response.data);
+  getAll({ text = "", sort_by, sort_order, skip = 0, take = 10 }) {
+    return api
+      .get("/users", {
+        params: {
+          text,
+          sort_by,
+          sort_order,
+          skip,
+          take,
+        },
+      })
+      .then((response) => {
+        const { metadata, users } = response.data;
+        return { metadata, users };
+      });
   }
 
   createUser(user_data) {


### PR DESCRIPTION
**Description**

1.) Server-side pagination to "Projects page" with options for how many items to display per page (25, 50, 100), along with the range of items on a page, and the total count of items.

2.) The search functionality dynamically filters the list of projects based on a search query.

3.) The sort functionality enables users to order the list of projects by specific attributes (name, datasets, created_at, updated_at) in either ascending or descending order.

**Related Issue(s)**

Closes #[242]

**Changes Made**

- [X] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Screenshots**
![Projects_Pagination](https://github.com/user-attachments/assets/85a34f0f-9641-43bf-aaf2-b5662169a744)

![Projects_Sorting](https://github.com/user-attachments/assets/9b4c9f34-1962-4c60-b20d-f68efed656ea)

![Projects_Searching](https://github.com/user-attachments/assets/00c35187-3627-4185-94e3-0a5ecb488340)

**Checklist**

Before submitting this PR, please make sure that:

- [X] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [X] You have reviewed your own code and resolved any merge conflicts.
- [ ] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.
