### PR TITLE
Update tar command to remove absolute paths from the archive

### DIFF
--- a/workers/workers/cmd.py
+++ b/workers/workers/cmd.py
@@ -160,7 +160,7 @@ def total_size(dir_path: Path | str):
 
 
 def tar(tar_path: Path | str, source_dir: Path | str) -> None:
-    command = ['tar', 'cf', str(tar_path), '--sparse', str(source_dir)]
+    command = ['tar', 'cf', str(tar_path), '--sparse', '-C', str(source_dir), '.']
     execute(command)
 
 


### PR DESCRIPTION
**Description**

Current command create tar files with full path of the directory. Ex:

running the command `tar cf /N/scratch/bioloop/foo.tar --sparse /N/project/bioloop/raw_data/test_dataset` produces a foo.tar when extracted

`tar xf foo.tar` produces the below hierarchy in the directory where it was extracted.
- N/
  - project/
    - bioloop/
      - raw_data/
        - test_dataset/
          - ... files/dirs of the dataset


`tar cf /N/scratch/bioloop/foo.tar --sparse -C /N/project/bioloop/raw_data/test_dataset .` removes absolute paths from the archive and when extracted just produces:

`tar xf foo.tar

- foo/
  - ... files/dirs of the dataset