### PR TITLE
Disable preflight check in download_file_from_sda function

### DIFF
--- a/workers/workers/workflow_utils.py
+++ b/workers/workers/workflow_utils.py
@@ -116,7 +116,7 @@ def download_file_from_sda(sda_file_path: str,
                            *,
                            celery_task: WorkflowTask = None,
                            verify_checksum: bool = True,
-                           preflight_check: bool = True) -> None:
+                           preflight_check: bool = False) -> None:
     """
     Before downloading, check if the file exists and the checksums match.
     If not, download from SDA and validate if the checksums match.


### PR DESCRIPTION
When this option is disabled during the integrated workflow, the archived tar file is re-downloaded from the SDA for the purpose of extraction and checksum validation. This ensures that the data archived is identical to the data we have inspected, providing us with added confidence in the integrity of the data.