### PR TITLE
Update get_all_datasets function to set default of archived as None to return all datasets

### DIFF
--- a/workers/workers/api.py
+++ b/workers/workers/api.py
@@ -132,7 +132,7 @@ def get_all_datasets(
         name=None,
         days_since_last_staged=None,
         deleted=False,
-        archived=False,
+        archived=None,
         bundle=False):
     with APIServerSession() as s:
         payload = {


### PR DESCRIPTION
The default value of archived was set to False, which resulted in only a few datasets being returned. The watch.py script uses this function to filter out already archived datasets, but it is not functioning correctly because it is not receiving all the datasets.