### PR TITLE
refactor: streamline dataset creation payload by removing data wrapper

### DIFF
--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -333,15 +333,11 @@ router.post(
         a new relation is created between dataset and given workflow_id'
     */
     const {
-      workflow_id, state, ingestion_space, data,
+      workflow_id, state, ingestion_space, ...data
     } = req.body;
 
-    const { origin_path } = data;
-
-    // remove whitespaces from dataset name
-    data.name = data.name.split(' ').join('-');
-
     if (ingestion_space) {
+      const { origin_path } = data;
       // if dataset's origin_path is a restricted for dataset creation, throw
       // error
       const restricted_ingestion_dirs = config.restricted_ingestion_dirs[ingestion_space].split(',');

--- a/ui/src/components/dataset/ingestion/IngestionStepper.vue
+++ b/ui/src/components/dataset/ingestion/IngestionStepper.vue
@@ -173,8 +173,8 @@ import config from "@/config";
 import datasetService from "@/services/dataset";
 import fileSystemService from "@/services/fs";
 import toast from "@/services/toast";
-import pm from "picomatch";
 import { watchDebounced } from "@vueuse/core";
+import pm from "picomatch";
 
 const STEP_KEYS = {
   DIRECTORY: "directory",
@@ -461,12 +461,11 @@ const removeDataset = () => {
 };
 
 const preIngestion = () => {
+  const nameFormatted = selectedFile.value.name?.replace(/\s/g, "-");
   return datasetService.create_dataset({
-    data: {
-      name: selectedFile.value.name,
-      type: config.dataset.types.DATA_PRODUCT.key,
-      origin_path: selectedFile.value.path,
-    },
+    name: nameFormatted,
+    type: config.dataset.types.DATA_PRODUCT.key,
+    origin_path: selectedFile.value.path,
     ingestion_space: searchSpace.value.key,
   });
 };

--- a/workers/workers/scripts/register_ondemand.py
+++ b/workers/workers/scripts/register_ondemand.py
@@ -19,12 +19,10 @@ class Registration:
         print(f'registering {self.dataset_type} {dataset_name}')
         wf = Workflow(celery_app=celery_app, **self.wf_body)
         dataset_payload = {
-            'data': {
-                'name': dataset_name,
-                'type': self.dataset_type,
-                'workflow_id': wf.workflow['_id'],
-                'origin_path': dataset_path
-            }
+            'name': dataset_name,
+            'type': self.dataset_type,
+            'workflow_id': wf.workflow['_id'],
+            'origin_path': dataset_path
         }
         # HTTP POST
         created_dataset = api.create_dataset(dataset_payload)

--- a/workers/workers/scripts/watch.py
+++ b/workers/workers/scripts/watch.py
@@ -117,11 +117,9 @@ class Register:
     def register_candidate(self, candidate: Path):
         logger.info(f'registering {self.dataset_type} dataset - {candidate.name}')
         dataset_payload = {
-            'data': {
-                'name': slugify_(candidate.name),
-                'type': self.dataset_type,
-                'origin_path': str(candidate.resolve()),
-            }
+            'name': slugify_(candidate.name),
+            'type': self.dataset_type,
+            'origin_path': str(candidate.resolve()),
         }
         created_dataset = api.create_dataset(dataset_payload)
         self.run_workflows(created_dataset)


### PR DESCRIPTION
1. Removed the previously added data wrapper in payload creation, as it conflicted with the worker code.
2. Moved name formatting and sanitization to the UI layer, since the worker relies on the slugify method for name sanitization, and the watch script expects sanitized names to align with those in the database. This ensures no further modifications occur at the API level.