### PR TITLE
use app_id for to get active workflows

### DIFF
--- a/api/src/routes/datasetUploads.js
+++ b/api/src/routes/datasetUploads.js
@@ -28,6 +28,7 @@ const get_dataset_active_workflows = async ({ dataset } = {}) => {
   const datasetWorkflowIds = dataset.workflows.map((wf) => wf.id);
   const workflowQueryResponse = await workflowService.getAll({
     workflow_ids: datasetWorkflowIds,
+    app_id: config.get('app_id'),
     status: 'ACTIVE',
   });
   return workflowQueryResponse.data.results;


### PR DESCRIPTION
**Description**

Added `app_id` field which is needed to correctly fetch workflows of a dataset for a given Bioloop instance.

**Changes Made**

- [x] Bug fixed
- [ ] Code refactored

**Checklist**

- [x] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.