### PR TITLE
Apply query persistance to file browser

### DIFF
--- a/ui/src/components/dataset/DatasetList.vue
+++ b/ui/src/components/dataset/DatasetList.vue
@@ -207,14 +207,13 @@
 
 <script setup>
 import useQueryPersistence from "@/composables/useQueryPersistence";
-import config from "@/config";
 import DatasetService from "@/services/dataset";
 import * as datetime from "@/services/datetime";
 import toast from "@/services/toast";
 import { formatBytes, isFeatureEnabled } from "@/services/utils";
+import { useAuthStore } from "@/stores/auth";
 import { useDatasetStore } from "@/stores/dataset";
 import { storeToRefs } from "pinia";
-import { useAuthStore } from "@/stores/auth";
 
 useSearchKeyShortcut();
 

--- a/ui/src/components/filebrowser/FileBrowser.vue
+++ b/ui/src/components/filebrowser/FileBrowser.vue
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <FileBrowserSearchModal ref="advancedSearchModal" @search="search_files" />
+  <FileBrowserSearchModal ref="advancedSearchModal" />
 </template>
 
 <script setup>
@@ -113,17 +113,15 @@ watch(pwd, (newValue, oldValue) => {
   get_file_list(pwd.value);
 });
 
-const nameRef = toRefs(store.filters).name;
-const debouncedNameFilter = refDebounced(nameRef, 215);
-
 watch(
-  [debouncedNameFilter],
+  filters,
   () => {
+    // console.log("filters changed", filters.value, isInSearchMode.value);
     if (isInSearchMode.value) {
       search_files();
     }
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 );
 
 const advancedSearchModal = ref(null);

--- a/ui/src/components/filebrowser/FileBrowser.vue
+++ b/ui/src/components/filebrowser/FileBrowser.vue
@@ -36,9 +36,9 @@
 
 <script setup>
 import datasetService from "@/services/dataset";
+import { filterByValues } from "@/services/utils";
 import { useFileBrowserStore } from "@/stores/fileBrowser";
 import { storeToRefs } from "pinia";
-import { filterByValues } from "@/services/utils";
 
 const store = useFileBrowserStore();
 const { pwd, filters, isInSearchMode, filterStatus } = storeToRefs(store);
@@ -101,16 +101,17 @@ function search_files() {
     });
 }
 
-watch(
-  pwd,
-  () => {
-    // navigating to a directory disables the search mode
-    store.resetFilters();
-    isInSearchMode.value = false;
-    get_file_list(pwd.value);
-  },
-  { immediate: true },
-);
+onMounted(() => {
+  get_file_list(pwd.value);
+});
+
+watch(pwd, (newValue, oldValue) => {
+  if (oldValue == null) return;
+  // navigating to a directory disables the search mode
+  store.resetFilters();
+  isInSearchMode.value = false;
+  get_file_list(pwd.value);
+});
 
 const nameRef = toRefs(store.filters).name;
 const debouncedNameFilter = refDebounced(nameRef, 215);

--- a/ui/src/components/filebrowser/FileBrowserSearchBar.vue
+++ b/ui/src/components/filebrowser/FileBrowserSearchBar.vue
@@ -22,21 +22,25 @@
 <script setup>
 import useSearchKeyShortcut from "@/composables/useSearchKeyShortcut";
 import { useFileBrowserStore } from "@/stores/fileBrowser";
+import { storeToRefs } from "pinia";
 
 const store = useFileBrowserStore();
+const { filters } = storeToRefs(store);
 useSearchKeyShortcut();
 
 const emit = defineEmits(["advancedSearch"]);
 
 const state = computed({
   get() {
-    return store.filters.name;
+    return filters.value.name;
   },
-  set(newValue) {
+  // debounce the user input so that state is not updated on every
+  // key
+  set: useDebounceFn((newValue) => {
     // console.log("setting  store.filters.name", newValue);
-    store.filters.name = newValue;
+    filters.value.name = newValue;
     // enable search view when the search input has value
     if (newValue) store.isInSearchMode = true;
-  },
+  }, 500),
 });
 </script>

--- a/ui/src/components/filebrowser/FileBrowserSearchModal.vue
+++ b/ui/src/components/filebrowser/FileBrowserSearchModal.vue
@@ -88,7 +88,7 @@
 
 <script setup>
 import { useFileBrowserStore } from "@/stores/fileBrowser";
-import { storeToRefs } from "pinia";
+// import { storeToRefs } from "pinia";
 // const emit = defineEmits(["update"]);
 
 // parent component can invoke these methods through the template ref
@@ -100,10 +100,13 @@ defineExpose({
 const emit = defineEmits(["search"]);
 
 const store = useFileBrowserStore();
-const { filters } = storeToRefs(store);
+// const { filters: storeFilters } = storeToRefs(store);
 
 const loading = ref(false);
 const visible = ref(false);
+
+// use in component state to not update the store's filter for evey keystroke
+const filters = ref(store.defaultFilters());
 
 function hide() {
   loading.value = false;
@@ -111,6 +114,8 @@ function hide() {
 }
 
 function show() {
+  // on modal open. set components filter values from store
+  filters.value = { ...store.filters };
   visible.value = true;
 }
 
@@ -153,7 +158,9 @@ const fileTypeOptions = [
 // );
 
 function handleSearch() {
+  // on search click, set store filters to components filters and close modal
   store.isInSearchMode = true;
+  store.setFilters({ ...filters.value });
   hide();
   emit("search");
 }

--- a/ui/src/components/filebrowser/FileSizeSelect.vue
+++ b/ui/src/components/filebrowser/FileSizeSelect.vue
@@ -39,7 +39,7 @@ const fileSizeOptions = [
   "MB",
   "GB",
   "TB",
-  "PB",
+  // "PB",
   // "EB",
   // "ZB",
   // "YB",
@@ -49,6 +49,7 @@ const size = ref(null);
 const units = ref(fileSizeOptions[0]);
 
 function encodeBytes(bytes) {
+  // console.log("encodeBytes", bytes);
   // 1024 -> (1, "KB")
   if (bytes === 0) {
     size.value = 0;
@@ -61,22 +62,27 @@ function encodeBytes(bytes) {
   }
 }
 
-watch(
-  () => props.modelValue,
-  () => {
-    if (props.modelValue === null || props.modelValue === undefined)
-      encodeBytes(0);
-    else if (!isFinite(props.modelValue))
-      encodeBytes(Math.pow(k, fileSizeOptions.length - 1));
-    else encodeBytes(props.modelValue);
-  },
-  { immediate: true },
-);
+onMounted(() => {
+  // console.log("FileSizeSelect mounted", props.modelValue);
+  if (props.modelValue === null || props.modelValue === undefined)
+    encodeBytes(0);
+  else if (!isFinite(props.modelValue))
+    // if modelValue is infinity, set size to 1023 and units to the largest unit
+    encodeBytes(1023 * Math.pow(k, fileSizeOptions.length - 1));
+  else encodeBytes(props.modelValue);
+});
 
 watch([size, units], () => {
   if (size.value) {
     const sizeNumeric = parseInt(size.value);
     const unitPower = fileSizeOptions.indexOf(units.value);
+
+    // size >= 1023 and unit is the largest unit, return Infinity
+    if (sizeNumeric >= 1023 && unitPower === fileSizeOptions.length - 1) {
+      emit("update:modelValue", Infinity);
+      return;
+    }
+
     emit("update:modelValue", sizeNumeric * Math.pow(k, unitPower));
   } else {
     emit("update:modelValue", 0);

--- a/ui/src/composables/useQueryPersistence.js
+++ b/ui/src/composables/useQueryPersistence.js
@@ -8,26 +8,47 @@ import { useRoute, useRouter } from "vue-router";
 //   }
 // }
 
-function safeJSONParse(json) {
+function safeJSONParse(...args) {
   try {
-    return JSON.parse(json);
+    return JSON.parse(...args);
   } catch (error) {
     return null;
   }
 }
 
+// Custom serialization to preserve Infinity
+const customStringify = (obj) => {
+  return JSON.stringify(obj, (key, value) => {
+    if (typeof value === "number") {
+      if (value === Infinity) return "__Infinity__";
+      if (value === -Infinity) return "__-Infinity__";
+    }
+    return value; // Keep other values as-is
+  });
+};
+
+// Custom deserialization to restore Infinity
+const customParse = (jsonString) => {
+  return safeJSONParse(jsonString, (key, value) => {
+    if (value === "__Infinity__") return Infinity;
+    if (value === "__-Infinity__") return -Infinity;
+    return value; // Keep other values as-is
+  });
+};
+
 /**
  * Custom Vue Composition Function for Query Parameter Persistence
  *
- * This composition function helps you manage query parameters in the URL and keep them
- * in sync with a reactive object in your Vue application.
+ * This composition function helps you manage query parameters in the URL and
+ * keep them in sync with a reactive object in your Vue application.
  *
  * @param {object} options - Configuration options.
  * @param {Ref} options.refObject - A Vue ref object that stores the query parameter state.
  * @param {object} options.defaultValueFn - The function that returns the default value for the query parameters.
  * @param {string} [options.key="q"] - The key to use in the URL for the query parameters.
  * @param {boolean} [options.history_push=true] - Set to `true` to use `router.push` for navigation;
- *                                                `false` to use `router.replace`.
+ *                                                `false` to use
+ *                                                `router.replace`.
  * @returns {Ref} - The same `refObject` with two-way binding to the URL query parameters.
  */
 export default function useQueryPersistence({
@@ -47,13 +68,13 @@ export default function useQueryPersistence({
     return Object.assign(
       {},
       defaultValueFn(),
-      safeJSONParse(route.query[key] || "{}") || {},
+      customParse(route.query[key] || "{}") || {},
     );
   };
 
   const set = (state) => {
     // if state is the same as defaultValue, remove the query param
-    if (JSON.stringify(state) === JSON.stringify(defaultValueFn())) {
+    if (customStringify(state) === customStringify(defaultValueFn())) {
       const query = Object.assign({}, route.query);
       delete query[key];
       return router_nav({
@@ -61,7 +82,7 @@ export default function useQueryPersistence({
       });
     }
     const query = {
-      [key]: JSON.stringify(state),
+      [key]: customStringify(state),
     };
     return router_nav({
       query: Object.assign({}, route.query, query),
@@ -69,13 +90,14 @@ export default function useQueryPersistence({
   };
 
   // set initial value from route query params
+  // console.log("setting initial value from route query params");
   refObject.value = get();
 
   // watch refObject and set route query params
   watch(
     refObject,
     async (newValue) => {
-      console.log("refObject changed", newValue);
+      // console.log("refObject changed, updating route", newValue);
       updating_route = true;
       await set(newValue);
       updating_route = false;
@@ -91,6 +113,7 @@ export default function useQueryPersistence({
     () => route.query[key],
     () => {
       if (!updating_route) {
+        // console.log("route query changed, updating refObject");
         refObject.value = get();
       }
     },

--- a/ui/src/stores/fileBrowser.js
+++ b/ui/src/stores/fileBrowser.js
@@ -1,6 +1,7 @@
-import { ref } from "vue";
-import { defineStore } from "pinia";
+import useQueryPersistence from "@/composables/useQueryPersistence";
 import { mapValues } from "@/services/utils";
+import { defineStore } from "pinia";
+import { ref } from "vue";
 
 export const useFileBrowserStore = defineStore("fileBrowser", () => {
   function defaultFilters() {
@@ -19,14 +20,43 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
   const isInSearchMode = ref(false);
   const filters = ref(defaultFilters());
 
+  const params = computed({
+    get: () => {
+      // console.log("params computed getting value");
+      return {
+        pwd: pwd.value,
+        isInSearchMode: isInSearchMode.value,
+        filters: filters.value,
+      };
+    },
+    set: (newValue) => {
+      // console.log("params computed setting new value", newValue);
+      pwd.value = newValue.pwd;
+      isInSearchMode.value = newValue.isInSearchMode;
+      filters.value = newValue.filters;
+    },
+  });
+
+  useQueryPersistence({
+    refObject: params,
+    defaultValueFn: () => ({
+      pwd: "",
+      isInSearchMode: false,
+      filters: defaultFilters(),
+    }),
+    key: "q",
+    history_push: true,
+  });
+
   function resetFilters() {
+    // console.log("resetting filters called");
     Object.keys(filters.value).forEach((key) => {
       filters.value[key] = defaults[key];
     });
   }
 
   function resetByKey(key) {
-    console.log("resetting", key, filters.value[key], defaults[key]);
+    // console.log("resetting", key, filters.value[key], defaults[key]);
     filters.value[key] = defaults[key];
   }
 
@@ -37,6 +67,7 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
   function reset() {
     pwd.value = "";
     isInSearchMode.value = false;
+    // console.log("resetting filters - reset");
     resetFilters();
   }
 

--- a/ui/src/stores/fileBrowser.js
+++ b/ui/src/stores/fileBrowser.js
@@ -10,7 +10,7 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
       location: "/",
       filetype: "any",
       extension: "",
-      minSize: null,
+      minSize: 0,
       maxSize: Infinity,
     };
   }
@@ -22,7 +22,7 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
 
   const params = computed({
     get: () => {
-      // console.log("params computed getting value");
+      console.log("params computed getting value");
       return {
         pwd: pwd.value,
         isInSearchMode: isInSearchMode.value,
@@ -30,7 +30,7 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
       };
     },
     set: (newValue) => {
-      // console.log("params computed setting new value", newValue);
+      console.log("params computed setting new value", newValue);
       pwd.value = newValue.pwd;
       isInSearchMode.value = newValue.isInSearchMode;
       filters.value = newValue.filters;
@@ -49,14 +49,14 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
   });
 
   function resetFilters() {
-    // console.log("resetting filters called");
+    console.log("resetting filters called");
     Object.keys(filters.value).forEach((key) => {
       filters.value[key] = defaults[key];
     });
   }
 
   function resetByKey(key) {
-    // console.log("resetting", key, filters.value[key], defaults[key]);
+    console.log("resetting", key, filters.value[key], defaults[key]);
     filters.value[key] = defaults[key];
   }
 
@@ -67,8 +67,12 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
   function reset() {
     pwd.value = "";
     isInSearchMode.value = false;
-    // console.log("resetting filters - reset");
+    console.log("resetting filters - reset");
     resetFilters();
+  }
+
+  function setFilters(val) {
+    filters.value = val;
   }
 
   return {
@@ -80,5 +84,6 @@ export const useFileBrowserStore = defineStore("fileBrowser", () => {
     defaultFilters,
     filterStatus,
     reset,
+    setFilters,
   };
 });


### PR DESCRIPTION
**Description**

Please provide a brief description of the changes made in this PR.

**Related Issue(s)**

Closes #[51]

If applicable, please reference the issue(s) that this PR addresses. If the PR does not address any specific issue, you can remove this section.

**Changes Made**

1.) Added Query persistence to the 'file browser', so users can navigate previous directory/ previous search result after navigation/search action. 

2.) It is done by manipulating browser url query parameters. These are the parameters used in the URL: 

i.) pwd
ii.) isInSearchMode
iii.) filters:  (It refers to the 'Advanced File Search' where user can change these parameters)

iv.) name
v.) location
vi.) filetype
vii.) extension
viii.) minsize
ix.) maxsize

List the main changes made in this PR. Be as specific as possible.

- [X] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Tests changed
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Screenshots (if applicable)**

Provide screenshots or GIFs that visually represent the changes. If not applicable, you can remove this section.

1.) ![Filebrowser_QP_AdvSearch](https://github.com/user-attachments/assets/817c90be-7504-4a7b-8516-6ab550979013)



2.) ![Filebrowser_QP_Searchquery](https://github.com/user-attachments/assets/dcc55b40-7b2f-42ed-8f2b-450a96547216)



**Checklist**

Before submitting this PR, please make sure that:

- [X] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [X] You have reviewed your own code and resolved any merge conflicts.
- [X] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.
