### PR TITLE
Skip checksum validation for symlinks in file validation process

### DIFF
--- a/workers/workers/tasks/validate.py
+++ b/workers/workers/tasks/validate.py
@@ -22,6 +22,9 @@ def check_files(celery_task: WorkflowTask, dataset_dir: Path, files_metadata: li
         rel_path = file_metadata['path']
         path = dataset_dir / rel_path
         if path.exists():
+            # for symlnks skip checksum validation
+            if path.is_symlink():
+                continue
             digest = utils.checksum(path)
             if digest != file_metadata['md5']:
                 validation_errors.append((str(path), 'checksum mismatch'))


### PR DESCRIPTION
The inspect step does not record the checksum of symlinks, causing validation errors when the validate step attempts to verify them. To resolve this, the validate step now only checks for the existence of the symlink without verifying its checksum.