### PR TITLE
fix(api): refine project access control logic for user roles

### DIFF
--- a/api/src/routes/projects.js
+++ b/api/src/routes/projects.js
@@ -244,9 +244,13 @@ router.get(
       userId: req.user.id,
     });
 
+    // has assoc, is user role  -> allowed
+    // has assoc, not user role -> allowed
+    // no assoc,  is user role  -> not allowed
+    // no assoc,  not user role -> allowed
     if (
-      req.user.roles.includes('user')
-        && !hasProjectAssociation
+      req.user.roles.length === 1
+      && req.user.roles.includes('user') && !hasProjectAssociation
     ) {
       return next(createError(403)); // Forbidden
     }

--- a/api/src/routes/projects.js
+++ b/api/src/routes/projects.js
@@ -244,13 +244,12 @@ router.get(
       userId: req.user.id,
     });
 
-    // has assoc, is user role  -> allowed
-    // has assoc, not user role -> allowed
-    // no assoc,  is user role  -> not allowed
-    // no assoc,  not user role -> allowed
+    // has assoc, has only user role              -> allowed
+    // has assoc, has operator / admin role       -> allowed
+    // no assoc,  has only user role              -> not allowed
+    // no assoc,  has operator / admin role       -> allowed
     if (
-      req.user.roles.length === 1
-      && req.user.roles.includes('user') && !hasProjectAssociation
+      !(req.user.roles.includes('operator') || req.user.roles.includes('admin')) && !hasProjectAssociation
     ) {
       return next(createError(403)); // Forbidden
     }


### PR DESCRIPTION
**Description**

Check if current user is under `user` role.

Previous:
```javascript
req.user.roles.includes('user')
```

Current:
```javascript
!(req.user.roles.includes('operator') || req.user.roles.includes('admin'))
```

This prevents cases where a user with multiple roles (user, operator) or (user, operator, admin) gets treated like having user role.

We should revisit role design in our application, and should probably make a user posses a single role, rather than multiple.

**Related Issue(s)**

**Changes Made**

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Tests changed
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Checklist**

Before submitting this PR, please make sure that:

- [x] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.

