### PR TITLE
api - in production only log error responses to reduce logging

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -24,7 +24,11 @@ const app = express();
 app.disable('x-powered-by');
 
 // request logger - https://github.com/expressjs/morgan
-app.use(requestLogger('dev'));
+if (config.get('mode') === 'production') {
+  app.use(requestLogger('combined', { skip: (req, res) => res.statusCode < 400 }));
+} else {
+  app.use(requestLogger('dev'));
+}
 
 // request parsing middleware
 app.use(express.json({ limit: '50mb' }));


### PR DESCRIPTION
This PR introduces conditional logging based on the environment mode (production or development). It configures different logging levels for HTTP requests:

- In production, logs are recorded only for requests with status codes 400 or higher, using the 'combined' format.
- In non-production (e.g., development), a more detailed 'dev' log format is used for all requests.

Production:
```
::1 - - [27/Nov/2024:06:21:42 +0000] "GET /combined HTTP/1.1" 401 2 "-" "curl/8.7.1"
```

Other envs:
```
GET /dev 200 0.224 ms - 2
```

more details: https://github.com/expressjs/morgan