### PR TITLE
Fix: API - optionally retrieve created dataset's relations

### DIFF
--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -394,7 +394,7 @@ router.post(
     // idempotence: creates dataset or returns error 409 on repeated requests
     // If many concurrent transactions are trying to create the same dataset, only one will succeed
     // will return dataset if successful, otherwise will return 409 so that client can handle next steps accordingly
-    const dataset = await datasetService.createDataset(data);
+    const dataset = await datasetService.createDataset({ data, include: CONSTANTS.INCLUDE_WORKFLOWS });
 
     if (dataset) res.json(dataset);
     else next(createError.Conflict('Unique constraint failed'));
@@ -508,7 +508,7 @@ router.post(
       });
 
     // create in separate transactions to avoid deadlocks
-    const results = await Promise.allSettled(data.map((d) => datasetService.createDataset(d)));
+    const results = await Promise.allSettled(data.map((d) => datasetService.createDataset({ data: d })));
 
     // separate results into created and failed
     const created = [];

--- a/api/src/services/dataset.js
+++ b/api/src/services/dataset.js
@@ -10,7 +10,7 @@ const userService = require('./user');
 const { log_axios_error } = require('../utils');
 const FileGraph = require('./fileGraph');
 const {
-  DONE_STATUSES, INCLUDE_STATES, INCLUDE_WORKFLOWS, INCLUDE_AUDIT_LOGS, INCLUDE_WORKFLOWS,
+  DONE_STATUSES, INCLUDE_STATES, INCLUDE_WORKFLOWS, INCLUDE_AUDIT_LOGS,
 } = require('../constants');
 
 const prisma = new PrismaClient();
@@ -511,9 +511,9 @@ function createDataset({data, include={}} = {}) {
         type: data.type,
         is_deleted: false,
       },
-      select: {
-        id: true,
-      },
+      // select: {
+      //   id: true,
+      // },
       ...(Object.keys(include).length > 0? { include } : {}),
     });
     if (existingDataset) {


### PR DESCRIPTION
**Description**

Allow retrieval of created dataset's relations in `POST datasets/` API.

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Tests changed
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Checklist**

Before submitting this PR, please make sure that:

- [x] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.