### PR TITLE
Add metadata to dataset creation and improve stability checks

### DIFF
--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -348,7 +348,7 @@ router.post(
 
     // gather non-null data to create a new dataset
     const data = _.flow([
-      _.pick(['name', 'type', 'origin_path', 'du_size', 'size', 'bundle_size']),
+      _.pick(['name', 'type', 'origin_path', 'du_size', 'size', 'bundle_size', 'metadata']),
       _.omitBy(_.isNil),
     ])(req.body);
 
@@ -434,7 +434,8 @@ router.post(
                                 "properties": {
                                     "name": "string",
                                     "type": "string",
-                                    "origin_path": "string"
+                                    "origin_path": "string",
+                                    "metadata": "object",
                                 },
                                 "required": ["name", "type", "origin_path"]
                             },
@@ -491,7 +492,10 @@ router.post(
 
     const data = req.body.datasets
       .map((d) => {
-        const _d = _.pick(['name', 'type', 'origin_path'])(d);
+        const _d = _.flow([
+          _.pick(['name', 'type', 'origin_path', 'metadata']),
+          _.omitBy(_.isNil),
+        ])(d);
 
         // normalize name
         _d.name = normalize_name(_d.name);

--- a/workers/workers/scripts/watch.py
+++ b/workers/workers/scripts/watch.py
@@ -64,6 +64,8 @@ class Register:
             'type': self.dataset_type,
             'origin_path': str(candidate.resolve()),
         }
+        if self.metadata:
+            dataset_payload['metadata'] = self.metadata
         try:
             created_dataset = api.create_dataset(dataset_payload)
             self.run_workflows(created_dataset)

--- a/workers/workers/tasks/await_stability.py
+++ b/workers/workers/tasks/await_stability.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from celery import Celery
 from celery.utils.log import get_task_logger
+from glom import glom
 
 import workers.api as api
 import workers.config.celeryconfig as celeryconfig
@@ -41,30 +42,51 @@ def dir_last_modified_time(dataset_path: Path) -> float:
     )
 
 
-def update_progress(celery_task, mod_time, delta):
+def update_progress(celery_task, mod_time, time_remaining_sec):
     d1 = datetime.datetime.utcfromtimestamp(mod_time)
     prog_obj = {
         'name': d1.isoformat(),
-        'time_remaining_sec': config['registration']['recency_threshold_seconds'] - delta,
+        'time_remaining_sec': time_remaining_sec,
     }
     celery_task.update_progress(prog_obj)
 
 
-def await_stability(celery_task, dataset_id, wait_seconds: int = None, **kwargs):
+def await_stability(celery_task, dataset_id, wait_seconds: int = None, recency_threshold=None, **kwargs):
     dataset = api.get_dataset(dataset_id=dataset_id)
     origin_path = Path(dataset['origin_path'])
+    dataset_type = dataset['type']
+
+    # recency_threshold is the time to wait before considering the dataset stable
+    # precedence order:
+    # 1. recency_threshold parameter
+    # 2. dataset metadata
+    # 3. config file
+    threshold = (recency_threshold or
+                 glom(dataset, 'metadata.recency_threshold_seconds', default=None) or
+                 config['registration'][dataset_type]['recency_threshold_seconds'])
+    logger.info(f'{dataset["name"]} - threshold: {threshold} seconds')
+
+    # wait_seconds is the time to wait between stability checks
+    # precedence order:
+    # 1. wait_seconds parameter
+    # 2. dataset metadata
+    # 3. config file
+    _wait_seconds = (wait_seconds or
+                     glom(dataset, 'metadata.wait_between_stability_checks_seconds', default=None) or
+                     config['registration']['wait_between_stability_checks_seconds'])
+    logger.info(f'{dataset["name"]} - wait_seconds: {_wait_seconds} seconds')
 
     while origin_path.exists():
         mod_time = dir_last_modified_time(origin_path)
         delta = time.time() - mod_time
 
         logger.info(f'{dataset["name"]} dataset is last modified {int(delta)}s ago')
-        update_progress(celery_task, mod_time, delta)
+        update_progress(celery_task, mod_time, threshold - delta)
 
-        if delta > config['registration']['recency_threshold_seconds']:
+        if delta > threshold:
             break
 
-        time.sleep(wait_seconds or config['registration']['wait_between_stability_checks_seconds'])
+        time.sleep(_wait_seconds)
 
     api.add_state_to_dataset(dataset_id=dataset_id, state='READY')
     return dataset_id,

--- a/workers/workers/tasks/await_stability.py
+++ b/workers/workers/tasks/await_stability.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from celery import Celery
 from celery.utils.log import get_task_logger
-from glom import glom
 
 import workers.api as api
 import workers.config.celeryconfig as celeryconfig
@@ -59,20 +58,16 @@ def await_stability(celery_task, dataset_id, wait_seconds: int = None, recency_t
     # recency_threshold is the time to wait before considering the dataset stable
     # precedence order:
     # 1. recency_threshold parameter
-    # 2. dataset metadata
-    # 3. config file
+    # 2. config file
     threshold = (recency_threshold or
-                 glom(dataset, 'metadata.recency_threshold_seconds', default=None) or
                  config['registration'][dataset_type]['recency_threshold_seconds'])
     logger.info(f'{dataset["name"]} - threshold: {threshold} seconds')
 
     # wait_seconds is the time to wait between stability checks
     # precedence order:
     # 1. wait_seconds parameter
-    # 2. dataset metadata
-    # 3. config file
+    # 2. config file
     _wait_seconds = (wait_seconds or
-                     glom(dataset, 'metadata.wait_between_stability_checks_seconds', default=None) or
                      config['registration']['wait_between_stability_checks_seconds'])
     logger.info(f'{dataset["name"]} - wait_seconds: {_wait_seconds} seconds')
 


### PR DESCRIPTION
**Description**

- Allow clients to send metadata while creating datasets (single, bulk)
- Add ability to attach metadata to datasets while ingesting from watch
- Await stability: control wait times between loops and recency thresholds through task parameters. These attributes can be set from workflow definitions and multiple workflows can have varied wait times, thresholds instead of static values from config.

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [x] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Tests changed
- [ ] Documentation updated
- [ ] Other changes: [describe]


**Checklist**

Before submitting this PR, please make sure that:

- [x] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.

**Additional Information**

These changes were first implemented and tested in CfNDAP.
