### PR TITLE
Add pagination and sort to derived datasets table.

### DIFF
--- a/api/prisma/seed.js
+++ b/api/prisma/seed.js
@@ -1,5 +1,6 @@
 const path = require('path');
 
+global.__basedir = path.join(__dirname, '..');
 const { PrismaClient } = require('@prisma/client');
 const _ = require('lodash/fp');
 const dayjs = require('dayjs');
@@ -14,8 +15,6 @@ const { generate_stage_request_logs } = require('./seed_data/stage_request_logs'
 const { generate_date_range } = require('../src/services/datetime');
 const datasetService = require('../src/services/dataset');
 const { readUsersFromJSON } = require('../src/utils');
-
-global.__basedir = path.join(__dirname, '..');
 
 const prisma = new PrismaClient();
 

--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -327,8 +327,6 @@ router.get(
       };
     }
     const datasetRetrievalQuery = {
-      skip: req.query.offset,
-      take: req.query.limit,
       ...filterQuery,
       orderBy,
       include: {
@@ -339,6 +337,14 @@ router.get(
         states: req.query.include_states || false,
       },
     };
+
+    if (req.query.offset != null) {
+      datasetRetrievalQuery.skip = req.query.offset;
+    }
+
+    if (req.query.limit != null) {
+      datasetRetrievalQuery.take = req.query.limit;
+    }
 
     const [datasets, count] = await prisma.$transaction([
       prisma.dataset.findMany({ ...datasetRetrievalQuery }),

--- a/api/src/routes/datasets.js
+++ b/api/src/routes/datasets.js
@@ -186,7 +186,7 @@ const buildQueryObject = ({
   deleted, archived, staged, type, name, days_since_last_staged,
   has_workflows, has_derived_data, has_source_data,
   created_at_start, created_at_end, updated_at_start, updated_at_end,
-  match_name_exact,
+  match_name_exact, id,
 }) => {
   const query_obj = _.omitBy(_.isUndefined)({
     is_deleted: deleted,
@@ -251,6 +251,16 @@ const buildQueryObject = ({
     };
   }
 
+  // id filter
+  if (id) {
+    // if id is an array, use 'in' operator
+    if (Array.isArray(id)) {
+      query_obj.id = { in: id };
+    } else {
+      query_obj.id = id;
+    }
+  }
+
   return query_obj;
 };
 
@@ -296,6 +306,7 @@ router.get(
     query('sort_order').default('desc').isIn(['asc', 'desc']),
     query('match_name_exact').default(false).toBoolean(),
     query('include_states').toBoolean().optional(),
+    query('id').isInt().toInt().optional(),
   ]),
   asyncHandler(async (req, res, next) => {
     // #swagger.tags = ['datasets']
@@ -308,6 +319,13 @@ router.get(
     const orderBy = {
       [req.query.sort_by]: req.query.sort_order,
     };
+    const optional_sort_columns = ['du_size', 'size', 'bundle_size'];
+    if (optional_sort_columns.includes(req.query.sort_by)) {
+      orderBy[req.query.sort_by] = {
+        nulls: 'last',
+        sort: req.query.sort_order,
+      };
+    }
     const datasetRetrievalQuery = {
       skip: req.query.offset,
       take: req.query.limit,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -26,6 +26,7 @@
         "markdown-it": "^14.0.0",
         "picomatch": "^4.0.2",
         "pinia": "^2.1.6",
+        "qs": "^6.14.0",
         "regex-username": "^2.0.0",
         "spark-md5": "^3.0.2",
         "the-big-username-blacklist": "^1.5.2",
@@ -1849,6 +1850,33 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2149,6 +2177,19 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2197,6 +2238,33 @@
       "integrity": "sha512-nU7xF7NoXrObmIGdXYwj1hfE3EH3jDVQ8oi1S5wG0yutrQILMJ3Xs0ZQEdGIjBQnFveDrAs/61m8/vm5SMvObA==",
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2749,6 +2817,41 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2827,6 +2930,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2840,6 +2954,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -3256,6 +3381,14 @@
       "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA==",
       "dev": true
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -3481,6 +3614,17 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -3944,6 +4088,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
@@ -4202,6 +4360,74 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "picomatch": "^4.0.2",
     "pinia": "^2.1.6",
     "regex-username": "^2.0.0",
+    "qs": "^6.14.0",
     "spark-md5": "^3.0.2",
     "the-big-username-blacklist": "^1.5.2",
     "turndown": "^7.1.2",

--- a/ui/src/components/dataset/AssocDatasetList.vue
+++ b/ui/src/components/dataset/AssocDatasetList.vue
@@ -1,23 +1,57 @@
 <template>
-  <va-data-table :items="datasets" :columns="columns" :loading="data_loading">
-    <template #cell(name)="{ rowData }">
-      <router-link :to="`/datasets/${rowData.id}`" class="va-link">
-        {{ rowData.name }}
-      </router-link>
-    </template>
+  <VaInnerLoading :loading="data_loading">
+    <va-data-table
+      :items="datasets"
+      :columns="columns"
+      v-model:sort-by="sort_by"
+      v-model:sorting-order="sort_order"
+      disable-client-side-sorting
+    >
+      <template #cell(name)="{ rowData }">
+        <router-link :to="`/datasets/${rowData.id}`" class="va-link">
+          {{ rowData.name }}
+        </router-link>
+      </template>
 
-    <template #cell(num_genome_files)="{ rowData }">
-      <Maybe :data="rowData?.metadata?.num_genome_files" />
-    </template>
+      <template #cell(du_size)="{ source }">
+        <span>{{ source != null ? formatBytes(source) : "" }}</span>
+      </template>
 
-    <template #cell(du_size)="{ source }">
-      <span>{{ source != null ? formatBytes(source) : "" }}</span>
-    </template>
+      <template #cell(created_at)="{ value }">
+        <span>{{ datetime.date(value) }}</span>
+      </template>
 
-    <template #cell(updated_at)="{ value }">
-      <span>{{ datetime.date(value) }}</span>
-    </template>
-  </va-data-table>
+      <template #cell(updated_at)="{ value }">
+        <span>{{ datetime.date(value) }}</span>
+      </template>
+
+      <template #cell(archive_path)="{ value }">
+        <span class="flex justify-center">
+          <Icon :icon="value ? 'mdi-check' : 'mdi-close'" />
+        </span>
+      </template>
+
+      <template #cell(is_staged)="{ value }">
+        <span class="flex justify-center">
+          <Icon :icon="value ? 'mdi-check' : 'mdi-close'" />
+        </span>
+      </template>
+      <template #cell(is_deleted)="{ value }">
+        <span class="flex justify-center">
+          <Icon :icon="value ? 'mdi-check' : 'mdi-close'" />
+        </span>
+      </template>
+    </va-data-table>
+    <!-- pagination -->
+    <Pagination
+      class="mt-4 px-1 lg:px-3"
+      v-model:page="page"
+      v-model:page_size="page_size"
+      :total_results="total_results"
+      :curr_items="datasets.length"
+      :page_size_options="PAGE_SIZE_OPTIONS"
+    />
+  </VaInnerLoading>
 </template>
 
 <script setup>
@@ -25,7 +59,6 @@ import DatasetService from "@/services/dataset";
 import * as datetime from "@/services/datetime";
 import toast from "@/services/toast";
 import { formatBytes } from "@/services/utils";
-import { useAuthStore } from "@/stores/auth";
 
 const props = defineProps({
   dataset_ids: {
@@ -34,60 +67,93 @@ const props = defineProps({
   },
 });
 
-const auth = useAuthStore();
-
 const datasets = ref([]);
 const data_loading = ref(false);
 
+// pagination
+const page = ref(1);
+const page_size = ref(10);
+const total_results = computed(() => props.dataset_ids.length);
+const PAGE_SIZE_OPTIONS = [5, 10, 20, 50, 100];
+const offset = computed(() => (page.value - 1) * page_size.value);
+
+// sorting
+const sort_by = ref("updated_at");
+const sort_order = ref("desc");
+
 const columns = ref([
-  // { key: "id", sortable: true, sortingOptions: ["desc", "asc", null] },
-  { key: "name", sortable: true, sortingOptions: ["desc", "asc", null] },
-  {
-    key: "updated_at",
-    label: "last updated",
-    sortable: true,
-    sortingOptions: ["desc", "asc", null],
-  },
-  ...(auth.isFeatureEnabled("genomeBrowser")
-    ? [
-        {
-          key: "num_genome_files",
-          label: "data files",
-          sortable: true,
-          sortingOptions: ["desc", "asc", null],
-        },
-      ]
-    : []),
+  // { key: "id", sortable: true,  },
+  { key: "name", sortable: true },
+  { key: "type", sortable: true },
   {
     key: "du_size",
     label: "size",
     sortable: true,
-    sortingOptions: ["desc", "asc", null],
     width: 80,
-    sortingFn: (a, b) => a - b,
+  },
+  { key: "created_at", label: "created on", sortable: true, width: "100px" },
+  {
+    key: "updated_at",
+    label: "last updated",
+    sortable: true,
+    width: "100px",
+  },
+  {
+    key: "archive_path",
+    label: "archived",
+    thAlign: "center",
+    tdAlign: "center",
+    width: "80px",
+  },
+  {
+    key: "is_staged",
+    label: "staged",
+    thAlign: "center",
+    tdAlign: "center",
+    width: "80px",
+  },
+  {
+    key: "is_deleted",
+    label: "deleted",
+    thAlign: "center",
+    tdAlign: "center",
+    width: "80px",
   },
 ]);
 
-watch(
-  [() => props.dataset_ids],
-  () => {
-    data_loading.value = true;
-    Promise.all(
-      props.dataset_ids.map((id) =>
-        DatasetService.getById({ id }).then((res) => res.data),
-      ),
-    )
-      .then((_datasets) => {
-        datasets.value = _datasets;
-      })
-      .catch((err) => {
-        console.error("Unable to fetch datasets", err);
-        toast.error("Unable to fetch datasets");
-      })
-      .finally(() => {
-        data_loading.value = false;
-      });
-  },
-  { immediate: true },
-);
+watch([() => props.dataset_ids], fetchDatasets, { immediate: true });
+watch(page, fetchDatasets);
+watch([page_size, sort_by, sort_order], () => {
+  if (page.value !== 1) {
+    page.value = 1;
+  } else {
+    fetchDatasets();
+  }
+});
+
+function fetchDatasets() {
+  if (!props.dataset_ids.length) {
+    return;
+  }
+  data_loading.value = true;
+  const ids_to_fetch = props.dataset_ids.slice(
+    offset.value,
+    offset.value + page_size.value,
+  );
+  DatasetService.getAll({
+    id: ids_to_fetch,
+    sort_by: sort_by.value,
+    sort_order: sort_order.value,
+  })
+    .then((res) => {
+      datasets.value = res.data.datasets;
+    })
+    .catch((err) => {
+      console.error("Unable to fetch datasets", err);
+      toast.error("Unable to fetch datasets");
+    })
+    .finally(() => {
+      data_loading.value = false;
+    });
+}
 </script>

--- a/ui/src/components/dataset/AssocDatasetList.vue
+++ b/ui/src/components/dataset/AssocDatasetList.vue
@@ -25,20 +25,20 @@
         <span>{{ datetime.date(value) }}</span>
       </template>
 
-      <template #cell(archive_path)="{ value }">
-        <span class="flex justify-center">
-          <Icon :icon="value ? 'mdi-check' : 'mdi-close'" />
+      <template #cell(archive_path)="{ source }">
+        <span v-if="source" class="flex justify-center">
+          <i-mdi-check-circle-outline class="text-green-700" />
         </span>
       </template>
 
-      <template #cell(is_staged)="{ value }">
-        <span class="flex justify-center">
-          <Icon :icon="value ? 'mdi-check' : 'mdi-close'" />
+      <template #cell(is_staged)="{ source }">
+        <span v-if="source" class="flex justify-center">
+          <i-mdi-check-circle-outline class="text-green-700" />
         </span>
       </template>
-      <template #cell(is_deleted)="{ value }">
-        <span class="flex justify-center">
-          <Icon :icon="value ? 'mdi-check' : 'mdi-close'" />
+      <template #cell(is_deleted)="{ source }">
+        <span v-if="source" class="flex justify-center">
+          <i-mdi-check-circle-outline class="text-green-700" />
         </span>
       </template>
     </va-data-table>

--- a/ui/src/components/dataset/AssocDatasets.vue
+++ b/ui/src/components/dataset/AssocDatasets.vue
@@ -7,9 +7,9 @@
           <span class="text-xl">Derived Datasets</span>
         </va-card-title>
         <va-card-content style="margin-top: -20px">
-          <assoc-dataset-list
+          <AssocDatasetList
             :dataset_ids="derived_datasets_meta.map((obj) => obj.derived_id)"
-          ></assoc-dataset-list>
+          ></AssocDatasetList>
         </va-card-content>
       </va-card>
     </div>
@@ -21,9 +21,9 @@
           <span class="text-xl">Source Datasets</span>
         </va-card-title>
         <va-card-content style="margin-top: -20px">
-          <assoc-dataset-list
+          <AssocDatasetList
             :dataset_ids="source_datasets_meta.map((obj) => obj.source_id)"
-          ></assoc-dataset-list>
+          ></AssocDatasetList>
         </va-card-content>
       </va-card>
     </div>

--- a/ui/src/services/dataset.js
+++ b/ui/src/services/dataset.js
@@ -1,9 +1,16 @@
 import config from "@/config";
 import toast from "@/services/toast";
-import api from "./api";
 import { useAuthStore } from "@/stores/auth";
+import qs from "qs";
+import api from "./api";
 
 const auth = useAuthStore();
+
+function cleanParams(params) {
+  return Object.fromEntries(
+    Object.entries(params).filter(([_, v]) => v !== null && v !== undefined),
+  );
+}
 
 class DatasetService {
   /**
@@ -29,7 +36,9 @@ class DatasetService {
       ? `/datasets/${auth.user.username}/all`
       : "/datasets";
     return api.get(url, {
-      params,
+      params: cleanParams(params),
+      paramsSerializer: (params) =>
+        qs.stringify(params, { arrayFormat: "repeat" }),
     });
   }
 

--- a/ui/src/services/dataset.js
+++ b/ui/src/services/dataset.js
@@ -35,6 +35,11 @@ class DatasetService {
     const url = !auth.canOperate
       ? `/datasets/${auth.user.username}/all`
       : "/datasets";
+    // What qs.stringify does?
+    // Before: /datasets?id[]=1&id[]=2&id[]=3
+    // After: /datasets?id=1&id=2&id=3
+    // qs.stringify preserves the parameters which are null/undefined. API doesn't expect null/undefined to be sent,
+    // so we need to clean the parameters (removes keys which have null/undefined value).
     return api.get(url, {
       params: cleanParams(params),
       paramsSerializer: (params) =>


### PR DESCRIPTION
**Description**

Added server-side pagination and sorting for the Derived Datasets table in the /datasets/:datasetId view.

Features:

1.) Only a subset of dataset_ids is sent to the backend based on the current page and page size, supporting pagination.
2.) Sorting by column triggers fresh server queries
3.) Added three new columns: Archived, Staged, and Deleted

**Related Issue(s)**

Closes #[431]

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [X] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Tests changed
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Screenshots (if applicable)**

![Pagination](https://github.com/user-attachments/assets/5fbf9b32-60fb-4e0e-a5d3-a7c700abc7f3)

![Sorting](https://github.com/user-attachments/assets/2c7eeadb-a5be-4b7d-b466-cdf500b1907e)


**Checklist**

Before submitting this PR, please make sure that:

- [X] Your code passes linting and coding style checks.
- [ ] Documentation has been updated to reflect the changes.
- [X] You have reviewed your own code and resolved any merge conflicts.
- [X] You have requested a review from at least one team member.
- [ ] Any relevant issue(s) have been linked to this PR.

**Additional Information**

Add any other information or context that may be relevant to this PR. This can include potential impacts, known issues, or future work related to this change.
