### PR TITLE
Build and deploy docs Vitepress site using Github Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+# Sample workflow for building and deploying a VitePress site to GitHub Pages
+#
+name: Deploy VitePress site to Pages
+
+on:
+  # Runs on pushes targeting the `main` branch. Change this to `master` if you're
+  # using the `master` branch as the default branch.
+  push:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+      # - uses: pnpm/action-setup@v3 # Uncomment this block if you're using pnpm
+      #   with:
+      #     version: 9 # Not needed if you've set "packageManager" in package.json
+      # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm # or pnpm / yarn
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Install dependencies
+        run: npm ci # or pnpm install / yarn install / bun install
+      - name: Build with VitePress
+        run: npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -5,7 +5,7 @@ import { withSidebar } from 'vitepress-sidebar';
 // https://vitepress.dev/reference/site-config
 let vitePressOptions =  {
   title: "Bioloop",
-  base: "/bioloop/docs/",
+  base: "/bioloop-test/docs/",
   description: "Bioloop Documentation",
   head: [['link', { rel: 'icon', href: '/bioloop/docs/favicon.ico' }]],
   lastUpdated: true, // Enable last updated timestamp

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -5,7 +5,7 @@ import { withSidebar } from 'vitepress-sidebar';
 // https://vitepress.dev/reference/site-config
 let vitePressOptions =  {
   title: "Bioloop",
-  base: "/bioloop-test/",
+  base: "/bioloop/",
   description: "Bioloop Documentation",
   head: [['link', { rel: 'icon', href: '/bioloop/docs/favicon.ico' }]],
   lastUpdated: true, // Enable last updated timestamp

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -5,7 +5,7 @@ import { withSidebar } from 'vitepress-sidebar';
 // https://vitepress.dev/reference/site-config
 let vitePressOptions =  {
   title: "Bioloop",
-  base: "/bioloop-test/docs/",
+  base: "/bioloop-test/",
   description: "Bioloop Documentation",
   head: [['link', { rel: 'icon', href: '/bioloop/docs/favicon.ico' }]],
   lastUpdated: true, // Enable last updated timestamp


### PR DESCRIPTION
Instructions: https://vitepress.dev/guide/deploy#github-pages

`base` path in config.mjs may need adjusting. It is set to `/bioloop/` assuming the site is going to be served at `https://iusca.github.io/bioloop/`