### PR TITLE
Added Metadata feature in User Management Page.

### DIFF
--- a/api/src/services/user.js
+++ b/api/src/services/user.js
@@ -219,7 +219,7 @@ async function hardDeleteUser(username) {
 
 async function updateUser(username, data) {
   const updates = _.flow([
-    _.pick(['username', 'name', 'email', 'cas_id', 'notes', 'is_deleted']),
+    _.pick(['username', 'name', 'email', 'cas_id', 'notes', 'is_deleted', 'metadata']),
     _.omitBy(_.isNil),
   ])(data);
 

--- a/docs/ui/components/KeyValueEditor.md
+++ b/docs/ui/components/KeyValueEditor.md
@@ -1,0 +1,60 @@
+# KeyValueEditor Component
+
+The `KeyValueEditor` is a Vue component for editing key-value pairs in a user-friendly table-like interface. It supports inline editing, adding, and removing key-value pairs, and emits updates to the parent component.
+
+## Features
+
+- Inline editing of keys and values
+- Add new key-value pairs
+- Remove existing pairs
+- Prevents duplicate keys
+- Customizable input widths and placeholders
+- Emits changes via `update:modelValue`
+
+## Props
+
+| Prop               | Type     | Default    | Description                                 |
+|--------------------|----------|------------|---------------------------------------------|
+| `modelValue`       | Object   | —          | The object to edit (required, v-model)      |
+| `keyWidth`         | String   | `150px`    | Width of the key input column               |
+| `valueWidth`       | String   | `250px`    | Width of the value input column             |
+| `keyPlaceholder`   | String   | `New Key`  | Placeholder for new key input               |
+| `valuePlaceholder` | String   | `Value`    | Placeholder for new value input             |
+| `emptyMessage`     | String   | `No key-value pairs. Add one below to get started.` | Message to show when there are no items     |
+
+## Events
+
+| Event                | Payload         | Description                        |
+|----------------------|----------------|------------------------------------|
+| `update:modelValue`  | `{...object}`  | Emitted when the object is updated |
+
+## Usage
+
+```vue
+<template>
+  <KeyValueEditor
+    v-model="myObject"
+    key-width="120px"
+    value-width="200px"
+    key-placeholder="Key"
+    value-placeholder="Value"
+  />
+</template>
+
+<script setup>
+import KeyValueEditor from '@/components/utils/KeyValueEditor.vue'
+import { ref } from 'vue'
+
+const myObject = ref({
+  foo: 'bar',
+  hello: 'world'
+})
+</script>
+```
+
+## Notes
+
+- Editing a key to an existing key will be prevented.
+- All changes are reactive and immediately emitted to the parent.
+- Clicking outside the editor will close any open edit fields.
+

--- a/ui/src/components/utils/KeyValueEditor.vue
+++ b/ui/src/components/utils/KeyValueEditor.vue
@@ -93,7 +93,7 @@
 
 <script setup>
 const props = defineProps({
-  modelValue: { type: Object, required: true },
+  modelValue: { type: Object, required: false, default: () => ({}) },
   keyWidth: { type: String, default: "150px" },
   valueWidth: { type: String, default: "250px" },
   keyPlaceholder: { type: String, default: "New Key" },
@@ -191,18 +191,18 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .key-input {
-  width: v-bind("keyWidth");
-  min-width: v-bind("keyWidth");
-  max-width: v-bind("keyWidth");
+  width: v-bind("props.keyWidth");
+  min-width: v-bind("props.keyWidth");
+  max-width: v-bind("props.keyWidth");
   display: inline-block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .value-input {
-  width: v-bind("valueWidth");
-  min-width: v-bind("valueWidth");
-  max-width: v-bind("valueWidth");
+  width: v-bind("props.valueWidth");
+  min-width: v-bind("props.valueWidth");
+  max-width: v-bind("props.valueWidth");
   display: inline-block;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ui/src/components/utils/KeyValueEditor.vue
+++ b/ui/src/components/utils/KeyValueEditor.vue
@@ -1,0 +1,234 @@
+<template>
+  <div class="" ref="tableRef">
+    <!-- Show message if localObject is empty -->
+    <div
+      v-if="Object.keys(localObject).length === 0"
+      class="va-text-secondary text-sm italic"
+    >
+      {{ props.emptyMessage }}
+    </div>
+    <div
+      v-for="(val, key, i) in localObject"
+      :key="key"
+      class="flex items-center gap-1 row-separator"
+      style="min-height: 32px"
+    >
+      <!-- Editable Key -->
+      <VaValue v-slot="vKey">
+        <VaInput
+          v-if="isEditing.type === 'key' && isEditing.index === i"
+          v-model="editableKeys[i]"
+          class="border rounded px-1 py-0.5 key-input key-col-separator"
+          @blur="toggleKeyEdit(i, key, vKey)"
+          @keyup.enter="toggleKeyEdit(i, key, vKey)"
+          ref="keyInputs"
+        />
+        <span
+          v-else
+          class="key-input truncate cursor-pointer key-col-separator pl-1"
+          role="button"
+          @keydown.enter="startEdit('key', i, vKey)"
+          tabindex="0"
+          @click="startEdit('key', i, vKey)"
+        >
+          {{ key }}
+        </span>
+      </VaValue>
+
+      <!-- Editable Value -->
+      <VaValue v-slot="vVal">
+        <VaInput
+          v-if="isEditing.type === 'value' && isEditing.index === i"
+          v-model="localObject[key]"
+          class="border rounded px-1 py-0.5 value-input"
+          @blur="stopEdit(vVal)"
+          @keyup.enter="stopEdit(vVal)"
+          ref="valueInputs"
+        />
+        <span
+          v-else
+          class="flex-1 truncate value-input cursor-pointer pl-1"
+          role="button"
+          @keydown.enter="startEdit('value', i, vVal)"
+          tabindex="0"
+          @click="startEdit('value', i, vVal)"
+        >
+          {{ localObject[key] }}
+        </span>
+      </VaValue>
+
+      <VaButton
+        icon="delete"
+        color="danger"
+        size="small"
+        preset="primary"
+        class="!p-0"
+        @click="removeKey(key)"
+      />
+    </div>
+
+    <!-- Add New KV -->
+    <div class="flex items-center gap-1 row-separator pt-1">
+      <VaInput
+        v-model="newKey"
+        :placeholder="props.keyPlaceholder"
+        class="border rounded px-1 py-0.5 key-input key-col-separator"
+      />
+      <VaInput
+        v-model="newValue"
+        :placeholder="props.valuePlaceholder"
+        class="border rounded px-1 py-0.5 value-input"
+      />
+      <VaButton
+        icon="add"
+        size="small"
+        color="success"
+        @click="addKeyValue"
+        :disabled="!newKey || newKey in localObject"
+        class="!p-0"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  modelValue: { type: Object, required: true },
+  keyWidth: { type: String, default: "150px" },
+  valueWidth: { type: String, default: "250px" },
+  keyPlaceholder: { type: String, default: "New Key" },
+  valuePlaceholder: { type: String, default: "Value" },
+  emptyMessage: {
+    type: String,
+    default: "No key-value pairs. Add one below to get started.",
+  },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const localObject = reactive({ ...props.modelValue });
+const editableKeys = reactive(Object.keys(localObject));
+const newKey = ref("");
+const newValue = ref("");
+
+// Track which field is being edited
+const isEditing = reactive({ type: null, index: null });
+
+// Helper to close any open edit
+function closeEdit() {
+  isEditing.type = null;
+  isEditing.index = null;
+}
+
+// Start editing a field, close any previous edit
+function startEdit(type, index, vSlot) {
+  closeEdit();
+  isEditing.type = type;
+  isEditing.index = index;
+  // For VaValue slot, set value to true to trigger input
+  vSlot.value = true;
+}
+
+// Stop editing a value field
+function stopEdit(vSlot) {
+  closeEdit();
+  vSlot.value = false;
+}
+
+// Modified toggleKeyEdit to close edit state
+function toggleKeyEdit(index, oldKey, vKeySlot) {
+  const newKeyVal = editableKeys[index];
+  if (vKeySlot.value && newKeyVal !== oldKey) {
+    if (newKeyVal in localObject) return; // avoid duplicates
+    localObject[newKeyVal] = localObject[oldKey];
+    delete localObject[oldKey];
+    editableKeys[index] = newKeyVal;
+  }
+  closeEdit();
+  vKeySlot.value = false;
+}
+
+function removeKey(key) {
+  delete localObject[key];
+  const idx = editableKeys.findIndex((k) => k === key);
+  if (idx >= 0) editableKeys.splice(idx, 1);
+  closeEdit();
+}
+
+function addKeyValue() {
+  if (!newKey.value || newKey.value in localObject) return;
+  localObject[newKey.value] = newValue.value;
+  editableKeys.push(newKey.value);
+  newKey.value = "";
+  newValue.value = "";
+  closeEdit();
+}
+
+watch(
+  localObject,
+  () => {
+    emit("update:modelValue", { ...localObject });
+  },
+  { deep: true },
+);
+
+// Optional: Close edit if user clicks outside the table
+const tableRef = ref(null);
+function handleClickOutside(event) {
+  // Only close edit if click is outside the table container
+  if (!tableRef.value) return;
+  if (!tableRef.value.contains(event.target)) {
+    closeEdit();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("mousedown", handleClickOutside);
+});
+onBeforeUnmount(() => {
+  document.removeEventListener("mousedown", handleClickOutside);
+});
+</script>
+
+<style scoped>
+.key-input {
+  width: v-bind("keyWidth");
+  min-width: v-bind("keyWidth");
+  max-width: v-bind("keyWidth");
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.value-input {
+  width: v-bind("valueWidth");
+  min-width: v-bind("valueWidth");
+  max-width: v-bind("valueWidth");
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.row-separator {
+  border-bottom: 0px solid #e5e7eb; /* subtle gray-200 */
+}
+.key-col-separator {
+  border-right: 1px solid #e5e7eb;
+  /* Add padding to separate from border */
+  padding-right: 8px !important;
+  margin-right: 4px;
+}
+
+/* Dark mode support */
+:root.dark .row-separator {
+  border-bottom-color: #374151; /* gray-700 */
+}
+:root.dark .key-col-separator {
+  border-right-color: #374151; /* gray-700 */
+}
+</style>
+
+<style scoped lang="scss">
+:deep(.va-input-wrapper__field) {
+  --va-input-wrapper-min-height: 20px;
+}
+</style>

--- a/ui/src/pages/users.vue
+++ b/ui/src/pages/users.vue
@@ -238,17 +238,6 @@
           </div>
 
           <!-- metadata -->
-          <!-- temporary view -->
-          <!-- <va-textarea
-            data-testid="user-metadata-input"
-            class="w-full text-sm"
-            :modelValue="JSON.stringify(editedUser.metadata || {}, null, 2)"
-            label="Metadata"
-            autosize
-            readonly
-            preset="solid"
-          /> -->
-          <!-- <JSONTable v-model="editedUser.metadata" editable /> -->
           <div class="flex-[1_1_100%]">
             <span
               class="block text-xs font-semibold mb-3"

--- a/ui/src/pages/users.vue
+++ b/ui/src/pages/users.vue
@@ -144,6 +144,7 @@
     <div class="max-w-lg">
       <va-inner-loading :loading="modal_loading">
         <va-form class="flex flex-wrap gap-2 gap-y-4" ref="modifyFormRef">
+          <!-- name -->
           <va-input
             data-testid="user-name-input"
             class="w-full"
@@ -153,6 +154,8 @@
               (value) => (value && value.length > 0) || 'Field is required',
             ]"
           />
+
+          <!-- email -->
           <va-input
             data-testid="user-email-input"
             v-model="editedUser.email"
@@ -162,6 +165,8 @@
               (value) => (value && value.length > 0) || 'Field is required',
             ]"
           />
+
+          <!-- username -->
           <va-input
             data-testid="user-username-input"
             :modelValue="editedUser.username || autofill.username"
@@ -172,6 +177,8 @@
               (value) => (value && value.length > 0) || 'Field is required',
             ]"
           />
+
+          <!-- cas id -->
           <va-input
             data-testid="user-cas-id-input"
             :modelValue="editedUser.cas_id || autofill.cas_id"
@@ -183,6 +190,7 @@
             ]"
           />
 
+          <!-- status -->
           <div class="flex-[1_1_100%] flex items-center gap-3">
             <div class="flex items-center gap-3">
               <span
@@ -213,6 +221,7 @@
             </div>
           </div>
 
+          <!-- roles -->
           <div class="flex-[1_1_100%]">
             <span
               class="block text-xs font-semibold mb-3"
@@ -228,8 +237,9 @@
             />
           </div>
 
+          <!-- metadata -->
           <!-- temporary view -->
-          <va-textarea
+          <!-- <va-textarea
             data-testid="user-metadata-input"
             class="w-full text-sm"
             :modelValue="JSON.stringify(editedUser.metadata || {}, null, 2)"
@@ -237,9 +247,19 @@
             autosize
             readonly
             preset="solid"
-          />
+          /> -->
           <!-- <JSONTable v-model="editedUser.metadata" editable /> -->
+          <div class="flex-[1_1_100%]">
+            <span
+              class="block text-xs font-semibold mb-3"
+              style="color: var(--va-primary)"
+            >
+              METADATA
+            </span>
+            <KeyValueEditor v-model="editedUser.metadata" />
+          </div>
 
+          <!-- notes -->
           <va-textarea
             data-testid="user-notes-input"
             class="w-full"


### PR DESCRIPTION
**Description**

Admin/Operator: Update the Metadata for any user. 

KeyValueEditor Component

The `KeyValueEditor` is a Vue component for editing key-value pairs in a user-friendly table-like interface. It supports inline editing, adding, and removing key-value pairs, and emits updates to the parent component.

Features

- Inline editing of keys and values
- Add new key-value pairs
- Remove existing pairs
- Prevents duplicate keys
- Customizable input widths and placeholders
- Emits changes via `update:modelValue`

**Related Issue(s)**

Closes #[462]

If applicable, please reference the issue(s) that this PR addresses. If the PR does not address any specific issue, you can remove this section.

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [X] Feature added
- [ ] Bug fixed
- [X] Code refactored
- [ ] Tests changed
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Screenshots (if applicable)**

![Metadata Insertion](https://github.com/user-attachments/assets/cbf21707-ff42-4e4b-a5d3-d4df5442ec60)
![Metadata Same Key Insertion](https://github.com/user-attachments/assets/95874d54-6d9d-43c2-8a48-5fbe77cff94d)


**Checklist**

Before submitting this PR, please make sure that:

- [X] Your code passes linting and coding style checks.
- [X] Documentation has been updated to reflect the changes.
- [X] You have reviewed your own code and resolved any merge conflicts.
- [X] You have requested a review from at least one team member.
- [X] Any relevant issue(s) have been linked to this PR.

**Additional Information**

Add any other information or context that may be relevant to this PR. This can include potential impacts, known issues, or future work related to this change.
