### PR TITLE
feat: add custom ESLint rules to prevent using the original Prisma client inside a transaction

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -1,4 +1,5 @@
 {  
+  "plugins": ["eslint-plugin-local-rules"],
   "settings": {
     "import/resolver": {
       "node": {
@@ -43,7 +44,8 @@
       }
     ],
     "max-len": ["error", { "ignoreComments": true, "code": 120 }],
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js"]}]
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js"]}],
+    "local-rules/no-original-prisma-inside-tx": "error"
   },
   "env": {
     "node": true,

--- a/api/eslint-local-rules.js
+++ b/api/eslint-local-rules.js
@@ -1,0 +1,96 @@
+// https://dev.to/jacobandrewsky/writing-local-rules-for-eslint-58bl
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-inner-declarations */
+module.exports = {
+  'no-original-prisma-inside-tx': {
+    // async function main() {
+    //   prisma.$transaction(async (tx) => {
+    //     await prisma.user.findFirst(); // ❌ incorrect, should use `tx`
+    //     await tx.user.findFirst(); // ✅ correct
+    //   });
+    // }
+    meta: {
+      type: 'problem',
+      docs: {
+        description: 'Disallow usage of original Prisma client inside a transaction callback',
+        recommended: true,
+      },
+      schema: [],
+    },
+    create(context) {
+      return {
+        CallExpression(node) {
+          // Match prisma.$transaction(...) where prisma is any identifier
+          // console.log('Checking node:', node.type, node.callee && node.callee.type,
+          // node.callee && node.callee.property && node.callee.property.name);
+          if (
+            node.callee
+              && node.callee.type === 'MemberExpression'
+              && node.callee.property.name === '$transaction'
+              && node.arguments.length >= 1
+          ) {
+            const originalClientName = node.callee.object.type === 'Identifier' ? node.callee.object.name : null;
+            const callbackFn = node.arguments[0];
+
+            if (!originalClientName
+                  || !['FunctionExpression', 'ArrowFunctionExpression'].includes(callbackFn.type)) {
+              return;
+            }
+
+            const txParam = callbackFn.params[0];
+            if (!txParam || txParam.type !== 'Identifier') return;
+
+            const txParamName = txParam.name;
+
+            // Walk inside callbackFn body
+            function checkNode(childNode) {
+              if (
+                childNode.type === 'MemberExpression'
+                  && childNode.object.type === 'Identifier'
+                  && childNode.object.name === originalClientName
+              ) {
+                context.report({
+                  node: childNode,
+                  message: `Do not use original Prisma client '${originalClientName}'`
+                    + ` inside a transaction. Use '${txParamName}' instead.`,
+                });
+              }
+            }
+
+            // const sourceCode = context.getSourceCode();
+            const callbackBody = callbackFn.body;
+            const visited = new WeakSet();
+
+            const traverse = (child) => {
+              if (!child || typeof child !== 'object' || visited.has(child)) {
+                return;
+              }
+              visited.add(child);
+
+              checkNode(child);
+              // Only traverse specific AST node properties to avoid circular references
+              // and prevent visiting parent nodes
+              const nodeProps = ['body', 'expression', 'expressions', 'left', 'right',
+                'object', 'property', 'callee', 'arguments', 'elements',
+                'properties', 'value', 'init', 'test', 'consequent',
+                'alternate', 'declarations', 'declarators', 'argument'];
+
+              for (const key of nodeProps) {
+                if (Object.prototype.hasOwnProperty.call(child, key)) {
+                  const val = child[key];
+                  if (Array.isArray(val)) {
+                    val.forEach(traverse);
+                  } else if (val && typeof val === 'object' && val.type) {
+                    traverse(val);
+                  }
+                }
+              }
+            };
+
+            traverse(callbackBody);
+          }
+        },
+      };
+    },
+  },
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -21,6 +21,7 @@
         "dayjs": "^1.11.10",
         "dompurify": "^3.0.9",
         "dotenv-safe": "^8.2.0",
+        "eslint-plugin-local-rules": "^3.0.2",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",
         "he": "^1.2.0",
@@ -3800,6 +3801,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/eslint-plugin-local-rules": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz",
+      "integrity": "sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ=="
     },
     "node_modules/eslint-plugin-lodash-fp": {
       "version": "2.2.0-a1",

--- a/api/package.json
+++ b/api/package.json
@@ -48,6 +48,7 @@
     "dayjs": "^1.11.10",
     "dompurify": "^3.0.9",
     "dotenv-safe": "^8.2.0",
+    "eslint-plugin-local-rules": "^3.0.2",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
     "he": "^1.2.0",
@@ -76,7 +77,7 @@
       "!src/_test.js"
     ]
   },
-    "_moduleAliases": {
+  "_moduleAliases": {
     "@": "src"
   }
 }

--- a/docs/api/07-development/tooling.md
+++ b/docs/api/07-development/tooling.md
@@ -71,6 +71,28 @@ Update `.eslintrc` to support module aliases:
 - `eslint-import-resolver-module-alias`
 - `eslint-import-resolver-node`
 
+
+## ESLint Local Rules
+To enforce specific coding practices, custom ESLint rules are defined in `eslint-local-rules.js`. These rules can be used to catch common mistakes or enforce project-specific conventions.
+
+### Example Rule: No Original Prisma Client Inside Transaction
+This rule prevents using the original Prisma client inside a transaction, ensuring that the transaction context is used instead.
+
+```javascript
+async function main() {
+  prisma.$transaction(async (tx) => {
+    await prisma.user.findFirst(); // ❌ incorrect, should use `tx`
+    await tx.user.findFirst(); // ✅ correct
+  });
+}
+```
+
+Test the rule with:
+```bash
+cd api/
+npx eslint src/ --rule 'local-rules/no-original-prisma-inside-tx: error'
+```
+
 ## EditorConfig
 
 Consistent Coding styles with .editorconfig


### PR DESCRIPTION
**Description**

## ESLint Local Rules
To enforce specific coding practices, custom ESLint rules are defined in `eslint-local-rules.js`. These rules can be used to catch common mistakes or enforce project-specific conventions.

### Example Rule: No Original Prisma Client Inside Transaction
This rule prevents using the original Prisma client inside a transaction, ensuring that the transaction context is used instead.

```javascript
async function main() {
  prisma.$transaction(async (tx) => {
    await prisma.user.findFirst(); // ❌ incorrect, should use `tx`
    await tx.user.findFirst(); // ✅ correct
  });
}
```

Test the rule with:
```bash
cd api/
npx eslint src/ --rule 'local-rules/no-original-prisma-inside-tx: error'
```

**Changes Made**

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Tests changed
- [x] Documentation updated
- [ ] Other changes: [describe]


**Checklist**

- [x] Your code passes linting and coding style checks.
- [x] Documentation has been updated to reflect the changes.
- [x] You have reviewed your own code and resolved any merge conflicts.
- [x] You have requested a review from at least one team member.
- [x] Any relevant issue(s) have been linked to this PR.
