### PR TITLE
bugfix(DatasetDownloadModal): add projectSlug prop to support project…

### DIFF
--- a/ui/src/components/project/datasets/DatasetDownloadModal.vue
+++ b/ui/src/components/project/datasets/DatasetDownloadModal.vue
@@ -144,6 +144,10 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  projectSlug: {
+    type: String,
+    default: null,
+  },
 });
 // const emit = defineEmits(["update"]);
 
@@ -154,6 +158,10 @@ defineExpose({
 });
 
 const downloadURL = computed(() => {
+  // when projectSlug is present, open the filebrowser within the project context
+  if(props.projectSlug) {
+    return `${window.location.origin}/projects/${props.projectSlug}/datasets/${props.dataset.id}/filebrowser`;
+  }
   return `${window.location.origin}/datasets/${props.dataset?.id}/filebrowser`;
 });
 

--- a/ui/src/components/project/datasets/ProjectDatasetsTable.vue
+++ b/ui/src/components/project/datasets/ProjectDatasetsTable.vue
@@ -164,7 +164,7 @@
   />
 
   <!-- Download Modal -->
-  <DatasetDownloadModal ref="downloadModal" :dataset="datasetToDownload" />
+  <DatasetDownloadModal ref="downloadModal" :dataset="datasetToDownload" :project-slug="props.project?.slug" />
 
   <!-- Stage Modal -->
   <StageDatasetModal


### PR DESCRIPTION
In the file download modal, clicking the **Download files** button should open the file browser within the project context:
/projects/<project_slug>/datasets/<dataset_id>/filebrowser

However, this behavior appears to have changed in recent months. The button now opens the file browser in the dataset context instead, which is restricted to operators and admins only.

This PR, adds a projectSlug prop to DatasetDownloadModal to build the URL conditionally.
