### PR TITLE
fix(download): allow nested file paths in download route

### DIFF
--- a/secure_download/src/routes/download.js
+++ b/secure_download/src/routes/download.js
@@ -33,7 +33,7 @@ function getFileStream(filePath) {
 }
 
 router.get(
-  '/:file_path',
+  '/:file_path(*)',
   validate([
     param('file_path').escape().notEmpty(),
   ]),


### PR DESCRIPTION
**Description**

This PR updates the /download route to support nested directory structures. Previously, the route used a single parameter match (/:file_path), which caused Express to return a 404 "Not Found" error whenever a file within a sub-folder (e.g., /46d61d754c2ebde3fd90a4d653b560e4/file01.txt) was requested.

The route now uses a wildcard parameter to capture the full path following the /download/ prefix, ensuring compatibility with complex file structures stored on external mounts.

**Changes Made**

List the main changes made in this PR. Be as specific as possible.

- [ ] Feature added
- [X] Bug fixed
- [ ] Code refactored
- [ ] Tests changed
- [ ] Documentation updated
- [ ] Other changes: [describe]

**Checklist**

Before submitting this PR, please make sure that:

- [X] Your code passes linting and coding style checks.
- [X] Documentation has been updated to reflect the changes.
- [X] You have reviewed your own code and resolved any merge conflicts.
- [ ] You have requested a review from at least one team member.
- [X] Any relevant issue(s) have been linked to this PR.
